### PR TITLE
feat: Add imagePullSecrets option to promitor-agent-scraper

### DIFF
--- a/promitor-agent-scraper/Chart.yaml
+++ b/promitor-agent-scraper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.0.0
+version: 2.1.0
 appVersion: 2.0.0
 type: application
 name: promitor-agent-scraper

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -59,6 +59,7 @@ their default values.
 | `image.repository`  | Repository which provides the image | `ghcr.io/tomkerkhove/promitor-agent-scraper` |
 | `image.tag`  | Tag of image to use | None, chart app version is used by default            |
 | `image.pullPolicy`  | Policy to pull image | `Always`            |
+| `image.pullSecrets`  | ImagePullSecrets for the pod | `[]`            |
 | `azureAuthentication.appId`  | Id of the Azure AD entity to authenticate with |             |
 | `azureAuthentication.appKey`  | Secret of the Azure AD entity to authenticate with |             |
 | `resourceDiscovery.enabled`  | Indication whether or not resource discovery is required | `false`            |

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -28,6 +28,10 @@ spec:
       {{- if .Values.rbac.create }}
       serviceAccountName: {{ template "promitor-agent-scraper.serviceaccountname" . }}
       {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -9,6 +9,7 @@ fullnameOverride: ""
 image:
   repository: ghcr.io/tomkerkhove/promitor-agent-scraper
   pullPolicy: Always
+  pullSecrets: []
   tag:
 
 azureAuthentication:


### PR DESCRIPTION
Hi.

Due to Docker hub quota drama we decided to migrate all internally used images to our own registry. This setting is required to pull the image from private registries.