### PR TITLE
fix: Rename `azureLandscape.subscriptionIds` to `azureLandscape.subscriptionIds` to avoid confusion

### DIFF
--- a/examples/promitor-agent-resource-discovery.config.yaml
+++ b/examples/promitor-agent-resource-discovery.config.yaml
@@ -4,7 +4,7 @@ azureAuthentication:
 azureLandscape:
   cloud: Global
   tenantId: c8819874-9e56-4e3f-b1a8-1c0325138f27
-  subscriptionIds:
+  subscriptions:
   - 0329dd2a-59dc-4493-aa54-cb01cb027dc2
   - 0f9d7fea-99e8-4768-8672-06a28514f77e
 resourceDiscoveryGroups:

--- a/promitor-agent-resource-discovery/README.md
+++ b/promitor-agent-resource-discovery/README.md
@@ -61,7 +61,7 @@ their default values.
 | `image.pullPolicy`  | Policy to pull image | `Always`            |
 | `azureLandscape.cloud`  | Azure Cloud to discover resources in. Options are `Global` (default), `China`, `UsGov` & `Germany` | `Global`            |
 | `azureLandscape.tenantId`  | Id of Azure tenant to discover resources in |             |
-| `azureLandscape.subscriptionIds`  | List of Azure subscription ids to discover resources in | `[]`            |
+| `azureLandscape.subscriptions`  | List of Azure subscription ids to discover resources in | `[]`            |
 | `resourceDiscoveryGroups`  | List of resource discovery groups to configured following the [resource discovery declaration docs](https://promitor.io/configuration/v2.x/resource-discovery) |        |
 | `azureAuthentication.appId`  | Id of the Azure AD entity to authenticate with |             |
 | `azureAuthentication.appKey`  | Secret of the Azure AD entity to authenticate with |             |

--- a/promitor-agent-resource-discovery/templates/configmap.yaml
+++ b/promitor-agent-resource-discovery/templates/configmap.yaml
@@ -1,5 +1,6 @@
 {{- $resourceDiscoveryGroups := toYaml .Values.resourceDiscoveryGroups -}}
 {{- $subscriptionIds := toYaml .Values.azureLandscape.subscriptionIds -}}
+{{- $subscriptions := toYaml .Values.azureLandscape.subscriptions -}}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -34,7 +35,12 @@ data:
     azureLandscape:
       tenantId: {{ .Values.azureLandscape.tenantId }}
       subscriptions:
+  {{- if .Values.azureLandscape.subscriptionIds }}
 {{ tpl $subscriptionIds . | indent 6 }}
+  {{- end }}
+  {{- if .Values.azureLandscape.subscriptions }}
+{{ tpl $subscriptions . | indent 6 }}
+  {{- end }}
       cloud: {{ .Values.azureLandscape.cloud }}
     resourceDiscoveryGroups:
 {{ tpl $resourceDiscoveryGroups . | indent 4 }}

--- a/promitor-agent-resource-discovery/values.yaml
+++ b/promitor-agent-resource-discovery/values.yaml
@@ -32,6 +32,8 @@ telemetry:
 azureLandscape:
   cloud: Global
   tenantId:
+  subscriptions: []
+  # This field is deprecated, use subscriptions instead please
   subscriptionIds: []
 
 resourceDiscoveryGroups: []


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Rename `azureLandscape.subscriptionIds` to `azureLandscape.subscriptionIds` to avoid confusion, but still allow the old approach for backwards compatability.

Fixes #27 
Relates to https://github.com/promitor/charts/issues/28
