### PR TITLE
feat: extend charts with additional parameters

### DIFF
--- a/promitor-agent-resource-discovery/README.md
+++ b/promitor-agent-resource-discovery/README.md
@@ -82,11 +82,22 @@ their default values.
 | `health.readiness.verifyDependencies`  | Indication if readiness probes should verify if Promitor can interat with external dependencies. Do note that this will contact all dependencies which can have performance impact, cause throttling or cascading failures when consumed very often. | `false`            |   |
 | `health.readiness.delay`  | Amount of seconds to wait before probing the container to verify if it's ready | `5`            |   |
 | `health.readiness.interval`  | Amount of seconds to wait before probing the container again to verify if it's ready after the last attempt | `5`            |   |
+| `health.readiness.thresholds.failure`  | Number of retries after first failed check before container will be marked `Unready`  | `3` |
+| `health.readiness.thresholds.success`  | Minimum consecutive successes for the probe to be considered successful after having failed | `1` |
+| `health.readiness.timeoutSeconds`  | Amount of seconds after which the probe times out | `1`  |
 | `health.liveness.enabled`  | Indication if liveness probes should be used | `true`            |   |
 | `health.liveness.verifyDependencies`  | Indication if liveness probes should verify if Promitor can interat with external dependencies. Do note that this will contact all dependencies which can have performance impact, cause throttling or cascading failures when consumed very often. | `false`            |   |
 | `health.liveness.delay`  | Amount of seconds to wait before probing the container to verify if it's still alive | `5`            |   |
 | `health.liveness.interval`  | Amount of seconds to wait before probing the container again to verify if it's still alive after the last attempt | `30`            |   |
+| `health.liveness.thresholds.failure`  | Number of retries after first failed check before container restart  | `3` |
+| `health.liveness.thresholds.success`  | Minimum consecutive successes for the probe to be considered successful after having failed | `1` |
+| `health.liveness.timeoutSeconds`  | Amount of seconds after which the probe times out | `1`  |
+| `affinity`  | Affinity settings ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)) |    `{}`    |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
+| `podLabels`  | Additional pod labels to include |    `{}`    |
+| `priorityClassName`  | Priority class to be used by pod ([docs](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)) |    `""`    |
+| `securityContext.*`  | Custom security context object for pod ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)) | `{}`            |
+| `securityContext.enabled`  | Whether to include custom security context for pod or not | `false`            |
 | `tolerations` | Tolerations for pod assignment | `[]` |
 | `resources`  | Pod resource requests & limits |    `{}`    |
 | `secrets.createSecret`  | Indication if you want to bring your own secret level of logging | `true`            |   |

--- a/promitor-agent-resource-discovery/templates/deployment.yaml
+++ b/promitor-agent-resource-discovery/templates/deployment.yaml
@@ -19,12 +19,18 @@ spec:
     metadata:
       labels:
         {{- include "promitor-agent-resource-discovery.selectorLabels" . | nindent 8 }}
+      {{- if .Values.podLabels }}
+      {{- toYaml .Values.podLabels | nindent 8 }}
+      {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.secrets.createSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
     spec:
+      {{- if .Values.securityContext.enabled }}
+      securityContext: {{- omit .Values.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       {{- if .Values.rbac.create }}
       serviceAccountName: {{ template "promitor-agent-resource-discovery.serviceaccountname" . }}
       {{- end }}
@@ -59,20 +65,32 @@ spec:
             mountPath: /config/
   {{- if .Values.health.liveness.enabled }}
           livenessProbe:
+            failureThreshold: {{ .Values.health.liveness.thresholds.failure }}
             httpGet:
               path: /api/v1/health?includeDependencies={{ .Values.health.liveness.verifyDependencies }}
               port: http
             initialDelaySeconds: {{ .Values.health.liveness.delay }}
             periodSeconds: {{ .Values.health.liveness.interval }}
+            successThreshold: {{ .Values.health.liveness.thresholds.success }}
+            timeoutSeconds: {{ .Values.health.liveness.timeoutSeconds }}
   {{- end }}
   {{- if .Values.health.readiness.enabled }}
           readinessProbe:
+            failureThreshold: {{ .Values.health.readiness.thresholds.failure }}
             httpGet:
               path: /api/v1/health?includeDependencies={{ .Values.health.readiness.verifyDependencies }}
               port: http
             initialDelaySeconds: {{ .Values.health.readiness.delay }}
             periodSeconds: {{ .Values.health.readiness.interval }}
+            successThreshold: {{ .Values.health.readiness.thresholds.success }}
+            timeoutSeconds: {{ .Values.health.readiness.timeoutSeconds }}
   {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       volumes:
         - name: config-volume-{{ template "promitor-agent-resource-discovery.name" . }}
           configMap:

--- a/promitor-agent-resource-discovery/values.yaml
+++ b/promitor-agent-resource-discovery/values.yaml
@@ -76,11 +76,25 @@ health:
     verifyDependencies: false
     delay: 5
     interval: 5
+    timeoutSeconds: 1
+    thresholds:
+      failure: 3
+      success: 1
   liveness:
     enabled: true
     verifyDependencies: false
     delay: 5
     interval: 30
+    timeoutSeconds: 1
+    thresholds:
+      failure: 3
+      success: 1
+
+affinity: {}
+
+podLabels: {}
+
+priorityClassName: ""
 
 resources: {}
   # limits:
@@ -112,4 +126,8 @@ rbac:
     annotations: {}
 
 nodeSelector: {}
+
+securityContext:
+  enabled: false
+
 tolerations: []

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -97,13 +97,24 @@ their default values.
 | `rbac.serviceAccount.annotations` | Service account annotations| `{}` |
 | `health.readiness.enabled`  | Indication if readiness probes should be used | `true`            |   |
 | `health.readiness.verifyDependencies`  | Indication if readiness probes should verify if Promitor can interat with external dependencies. Do note that this will contact all dependencies which can have performance impact, cause throttling or cascading failures when consumed very often. | `false`            |   |
-| `health.readiness.delay`  | Amount of seconds to wait before probing the container to verify if it's ready | `5`            |   |
-| `health.readiness.interval`  | Amount of seconds to wait before probing the container again to verify if it's ready after the last attempt | `5`            |   |
+| `health.readiness.delay`  | Amount of seconds to wait before probing the container to verify if it's ready | `5` |
+| `health.readiness.interval`  | Amount of seconds to wait before probing the container again to verify if it's ready after the last attempt | `5`            |
+| `health.readiness.thresholds.failure`  | Number of retries after first failed check before container will be marked `Unready`  | `3` |
+| `health.readiness.thresholds.success`  | Minimum consecutive successes for the probe to be considered successful after having failed | `1` |
+| `health.readiness.timeoutSeconds`  | Amount of seconds after which the probe times out | `1`  |
 | `health.liveness.enabled`  | Indication if liveness probes should be used | `true`            |   |
 | `health.liveness.verifyDependencies`  | Indication if liveness probes should verify if Promitor can interat with external dependencies. Do note that this will contact all dependencies which can have performance impact, cause throttling or cascading failures when consumed very often. | `false`            |   |
 | `health.liveness.delay`  | Amount of seconds to wait before probing the container to verify if it's still alive | `5`            |   |
-| `health.liveness.interval`  | Amount of seconds to wait before probing the container again to verify if it's still alive after the last attempt | `30`            |   |
+| `health.liveness.interval`  | Amount of seconds to wait before probing the container again to verify if it's still alive after the last attempt | `30`            |
+| `health.liveness.thresholds.failure`  | Number of retries after first failed check before container restart  | `3` |
+| `health.liveness.thresholds.success`  | Minimum consecutive successes for the probe to be considered successful after having failed | `1` |
+| `health.liveness.timeoutSeconds`  | Amount of seconds after which the probe times out | `1`  |
+| `affinity`  | Affinity settings ([docs](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity)) |    `{}`    |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
+| `podLabels`  | Additional pod labels to include |    `{}`    |
+| `priorityClassName`  | Priority class to be used by pod ([docs](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)) |    `""`    |
+| `securityContext.*`  | Custom security context object for pod ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)) | `{}`            |
+| `securityContext.enabled`  | Whether to include custom security context for pod or not | `false`            |
 | `tolerations` | Tolerations for pod assignment | `[]` |
 | `resources`  | Pod resource requests & limits |    `{}`    |
 | `secrets.createSecret`  | Indication if you want to bring your own secret level of logging | `true`            |

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -19,12 +19,18 @@ spec:
     metadata:
       labels:
         {{- include "promitor-agent-scraper.selectorLabels" . | nindent 8 }}
+      {{- if .Values.podLabels }}
+      {{- toYaml .Values.podLabels | nindent 8 }}
+      {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.secrets.createSecret }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
     spec:
+      {{- if .Values.securityContext.enabled }}
+      securityContext: {{- omit .Values.securityContext "enabled" | toYaml | nindent 8 }}
+      {{- end }}
       {{- if .Values.rbac.create }}
       serviceAccountName: {{ template "promitor-agent-scraper.serviceaccountname" . }}
       {{- end }}
@@ -73,20 +79,32 @@ spec:
             mountPath: /config/
   {{- if .Values.health.liveness.enabled }}
           livenessProbe:
+            failureThreshold: {{ .Values.health.liveness.thresholds.failure }}
             httpGet:
               path: /api/v1/health?includeDependencies={{ .Values.health.liveness.verifyDependencies }}
               port: http
             initialDelaySeconds: {{ .Values.health.liveness.delay }}
             periodSeconds: {{ .Values.health.liveness.interval }}
+            successThreshold: {{ .Values.health.liveness.thresholds.success }}
+            timeoutSeconds: {{ .Values.health.liveness.timeoutSeconds }}
   {{- end }}
   {{- if .Values.health.readiness.enabled }}
           readinessProbe:
+            failureThreshold: {{ .Values.health.readiness.thresholds.failure }}
             httpGet:
               path: /api/v1/health?includeDependencies={{ .Values.health.readiness.verifyDependencies }}
               port: http
             initialDelaySeconds: {{ .Values.health.readiness.delay }}
             periodSeconds: {{ .Values.health.readiness.interval }}
+            successThreshold: {{ .Values.health.readiness.thresholds.success }}
+            timeoutSeconds: {{ .Values.health.readiness.timeoutSeconds }}
   {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity: {{- tpl (toYaml .) $ | nindent 8 }}
+      {{- end }}
       volumes:
         - name: config-volume-{{ template "promitor-agent-scraper.name" . }}
           configMap:

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -95,11 +95,25 @@ health:
     verifyDependencies: false
     delay: 5
     interval: 5
+    timeoutSeconds: 1
+    thresholds:
+      failure: 3
+      success: 1
   liveness:
     enabled: true
     verifyDependencies: false
     delay: 5
     interval: 30
+    timeoutSeconds: 1
+    thresholds:
+      failure: 3
+      success: 1
+
+affinity: {}
+
+podLabels: {}
+
+priorityClassName: ""
 
 resources: {}
   # limits:
@@ -131,4 +145,8 @@ rbac:
     annotations: {}
 
 nodeSelector: {}
+
+securityContext:
+  enabled: false
+
 tolerations: []


### PR DESCRIPTION
Extends both charts with following configurations:
- add optional securityContext object
- add affinity configuration
- add priorityClassName 
- add additional podLabels (e.g. `CostCenter=IT`)
- add configurable values for probes
  - failureThreshold
  - successThreshold
  - timeoutSeconds