### PR TITLE
feat: Support Prometheus Operator in Helm chart

### DIFF
--- a/promitor-agent-scraper/Chart.yaml
+++ b/promitor-agent-scraper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.2.0
+version: 2.1.0
 appVersion: 2.0.0
 type: application
 name: promitor-agent-scraper

--- a/promitor-agent-scraper/Chart.yaml
+++ b/promitor-agent-scraper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.1.0
+version: 2.2.0
 appVersion: 2.0.0
 type: application
 name: promitor-agent-scraper

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -74,7 +74,7 @@ their default values.
 | `metricSinks.prometheusScrapingEndpoint.enableMetricTimestamps`  | Indication whether or not to include timestamp | `true`            |
 | `metricSinks.prometheusScrapingEndpoint.metricUnavailableValue`  | Value to report in Prometheus when no metric was found whether or not to include timestamp | `NaN`            |
 | `metricSinks.prometheusScrapingEndpoint.enableServiceDiscovery`  | Indication whether or not service discovery with annotations should be enabled ([docs](https://github.com/helm/charts/tree/master/stable/prometheus#scraping-pod-metrics-via-annotations)) | `true`            |
-| `metricSinks.prometheusScrapingEndpoint.serviceMonitor.enabled`  | Indication whether or not to create a ServiceMonitor object for Prometheus Operator | `false`            |
+| `metricSinks.prometheusScrapingEndpoint.serviceMonitor.enabled`  | Indication whether or not to create a ServiceMonitor object for [Prometheus Operator](https://github.com/prometheus-operator/prometheus-operator#customresourcedefinitions) | `false`            |
 | `metricSinks.prometheusScrapingEndpoint.serviceMonitor.namespace`  | The namespace where the ServiceMonitor should be created |                  |
 | `metricSinks.prometheusScrapingEndpoint.serviceMonitor.labels`  | Labels for the ServiceMonitor |       `{}`           |
 | `metricSinks.prometheusScrapingEndpoint.serviceMonitor.interval`  | How often Prometheus should scrape  | `60s`            |
@@ -83,7 +83,7 @@ their default values.
 | `metricSinks.statsd.host`  | DNS name or IP address of StatsD server |             |
 | `metricSinks.statsd.port`  | Port (UDP) address of StatsD server | `8125`            |
 | `metricSinks.statsd.metricPrefix`  | Prefix that will be added to every metric defined in the metric declaration |             |
-| `prometheusRule.enabled`          | Indication whether or not to create PrometheusRule object(s) for Prometheus operator      | `false`                     |
+| `prometheusRule.enabled`          | Indication whether or not to create PrometheusRule object(s) for [Prometheus operator](https://github.com/prometheus-operator/prometheus-operator#customresourcedefinitions)      | `false`                     |
 | `prometheusRule.additionalLabels` | Additional labels that can be used so prometheusRules will be discovered by Prometheus  | `{}`        |
 | `prometheusRule.namespace`        | namespace where prometheusRules object should be created          |                             |
 | `prometheusRule.rules`            | [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created | `[]` 

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -74,6 +74,15 @@ their default values.
 | `metricSinks.prometheusScrapingEndpoint.enableMetricTimestamps`  | Indication whether or not to include timestamp | `true`            |
 | `metricSinks.prometheusScrapingEndpoint.metricUnavailableValue`  | Value to report in Prometheus when no metric was found whether or not to include timestamp | `NaN`            |
 | `metricSinks.prometheusScrapingEndpoint.enableServiceDiscovery`  | Indication whether or not service discovery with annotations should be enabled ([docs](https://github.com/helm/charts/tree/master/stable/prometheus#scraping-pod-metrics-via-annotations)) | `true`            |
+| `metricSinks.prometheusOperator.serviceMonitor.enabled`  | Indication whether or not to create a ServiceMonitor object for Prometheus Operator | `false`            |
+| `metricSinks.prometheusOperator.serviceMonitor.namespace`  | The namespace where the ServiceMonitor should be created |                  |
+| `metricSinks.prometheusOperator.serviceMonitor.labels`  | Labels for the ServiceMonitor |       `{}`           |
+| `metricSinks.prometheusOperator.serviceMonitor.interval`  | How often Prometheus should scrape  | `60s`            |
+| `metricSinks.prometheusOperator.serviceMonitor.timeout`  | Timeout for the scraping operation | `10s`            |
+| `metricSinks.prometheusOperator.prometheusRule.enabled`          | Indication whether or not to create prometheusRules for Prometheus operator      | `false`                     |
+| `metricSinks.prometheusOperator.prometheusRule.additionalLabels` | Additional labels that can be used so prometheusRules will be discovered by Prometheus  | `{}`        |
+| `metricSinks.prometheusOperator.prometheusRule.namespace`        | namespace where prometheusRules object should be created          |                             |
+| `metricSinks.prometheusOperator.prometheusRule.rules`            | [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created | `[]` 
 | `metricSinks.statsd.enabled`  | Indication whether or not metrics should be emitted to a StatsD server | `false`|
 | `metricSinks.statsd.host`  | DNS name or IP address of StatsD server |             |
 | `metricSinks.statsd.port`  | Port (UDP) address of StatsD server | `8125`            |

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -74,19 +74,19 @@ their default values.
 | `metricSinks.prometheusScrapingEndpoint.enableMetricTimestamps`  | Indication whether or not to include timestamp | `true`            |
 | `metricSinks.prometheusScrapingEndpoint.metricUnavailableValue`  | Value to report in Prometheus when no metric was found whether or not to include timestamp | `NaN`            |
 | `metricSinks.prometheusScrapingEndpoint.enableServiceDiscovery`  | Indication whether or not service discovery with annotations should be enabled ([docs](https://github.com/helm/charts/tree/master/stable/prometheus#scraping-pod-metrics-via-annotations)) | `true`            |
-| `metricSinks.prometheusOperator.serviceMonitor.enabled`  | Indication whether or not to create a ServiceMonitor object for Prometheus Operator | `false`            |
-| `metricSinks.prometheusOperator.serviceMonitor.namespace`  | The namespace where the ServiceMonitor should be created |                  |
-| `metricSinks.prometheusOperator.serviceMonitor.labels`  | Labels for the ServiceMonitor |       `{}`           |
-| `metricSinks.prometheusOperator.serviceMonitor.interval`  | How often Prometheus should scrape  | `60s`            |
-| `metricSinks.prometheusOperator.serviceMonitor.timeout`  | Timeout for the scraping operation | `10s`            |
-| `metricSinks.prometheusOperator.prometheusRule.enabled`          | Indication whether or not to create prometheusRules for Prometheus operator      | `false`                     |
-| `metricSinks.prometheusOperator.prometheusRule.additionalLabels` | Additional labels that can be used so prometheusRules will be discovered by Prometheus  | `{}`        |
-| `metricSinks.prometheusOperator.prometheusRule.namespace`        | namespace where prometheusRules object should be created          |                             |
-| `metricSinks.prometheusOperator.prometheusRule.rules`            | [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created | `[]` 
+| `metricSinks.prometheusScrapingEndpoint.serviceMonitor.enabled`  | Indication whether or not to create a ServiceMonitor object for Prometheus Operator | `false`            |
+| `metricSinks.prometheusScrapingEndpoint.serviceMonitor.namespace`  | The namespace where the ServiceMonitor should be created |                  |
+| `metricSinks.prometheusScrapingEndpoint.serviceMonitor.labels`  | Labels for the ServiceMonitor |       `{}`           |
+| `metricSinks.prometheusScrapingEndpoint.serviceMonitor.interval`  | How often Prometheus should scrape  | `60s`            |
+| `metricSinks.prometheusScrapingEndpoint.serviceMonitor.timeout`  | Timeout for the scraping operation | `10s`            |
 | `metricSinks.statsd.enabled`  | Indication whether or not metrics should be emitted to a StatsD server | `false`|
 | `metricSinks.statsd.host`  | DNS name or IP address of StatsD server |             |
 | `metricSinks.statsd.port`  | Port (UDP) address of StatsD server | `8125`            |
 | `metricSinks.statsd.metricPrefix`  | Prefix that will be added to every metric defined in the metric declaration |             |
+| `prometheusRule.enabled`          | Indication whether or not to create PrometheusRule object(s) for Prometheus operator      | `false`                     |
+| `prometheusRule.additionalLabels` | Additional labels that can be used so prometheusRules will be discovered by Prometheus  | `{}`        |
+| `prometheusRule.namespace`        | namespace where prometheusRules object should be created          |                             |
+| `prometheusRule.rules`            | [rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) to be created | `[]` 
 | `telemetry.applicationInsights.enabled`  | Indication whether or not to send telemetry to Azure Application Insights | `false`            |
 | `telemetry.applicationInsights.logLevel`  | Minimum level of logging for Azure Application Insights |             |
 | `telemetry.applicationInsights.key`  | Application Insights instrumentation key |             |

--- a/promitor-agent-scraper/templates/prometheusrule.yaml
+++ b/promitor-agent-scraper/templates/prometheusrule.yaml
@@ -7,10 +7,7 @@ metadata:
   namespace: {{ . }}
 {{- end }}
   labels:
-    app: {{ template "promitor-agent-scraper.name" . }}
-    chart: {{ template "promitor-agent-scraper.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
+{{- include "promitor-agent-scraper.labels" . | nindent 4 }}
 {{- with .Values.prometheusRule.additionalLabels }}
 {{ toYaml . | indent 4 }}
 {{- end }}

--- a/promitor-agent-scraper/templates/prometheusrule.yaml
+++ b/promitor-agent-scraper/templates/prometheusrule.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.metricSinks.prometheusOperator.prometheusRule.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ template "promitor-agent-scraper" . }}
+{{- with .Values.metricSinks.prometheusOperator.prometheusRule.namespace }}
+  namespace: {{ . }}
+{{- end }}
+  labels:
+    app: {{ template "promitor-agent-scraper.name" . }}
+    chart: {{ template "promitor-agent-scraper.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
+{{- with .Values.metricSinks.prometheusOperator.prometheusRule.additionalLabels }}
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+{{- with .Values.metricSinks.prometheusOperator.prometheusRule.rules }}
+  groups:
+    - name: {{ template "promitor-agent-scraper.name" $ }}
+      rules: {{ tpl (toYaml .) $ | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/promitor-agent-scraper/templates/prometheusrule.yaml
+++ b/promitor-agent-scraper/templates/prometheusrule.yaml
@@ -1,9 +1,9 @@
-{{- if .Values.metricSinks.prometheusOperator.prometheusRule.enabled }}
+{{- if .Values.prometheusRule.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ template "promitor-agent-scraper" . }}
-{{- with .Values.metricSinks.prometheusOperator.prometheusRule.namespace }}
+{{- with .Values.prometheusRule.namespace }}
   namespace: {{ . }}
 {{- end }}
   labels:
@@ -11,11 +11,11 @@ metadata:
     chart: {{ template "promitor-agent-scraper.chart" . }}
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
-{{- with .Values.metricSinks.prometheusOperator.prometheusRule.additionalLabels }}
+{{- with .Values.prometheusRule.additionalLabels }}
 {{ toYaml . | indent 4 }}
 {{- end }}
 spec:
-{{- with .Values.metricSinks.prometheusOperator.prometheusRule.rules }}
+{{- with .Values.prometheusRule.rules }}
   groups:
     - name: {{ template "promitor-agent-scraper.name" $ }}
       rules: {{ tpl (toYaml .) $ | nindent 8 }}

--- a/promitor-agent-scraper/templates/servicemonitor.yaml
+++ b/promitor-agent-scraper/templates/servicemonitor.yaml
@@ -28,6 +28,5 @@ spec:
     - {{ .Release.Namespace }}
   selector:
     matchLabels:
-      app: {{ template "promitor-agent-scraper.name" . }}
-      release: {{ .Release.Name }}
+      {{- include "promitor-agent-scraper.selectorLabels" . | nindent 6 }}
 {{- end }}

--- a/promitor-agent-scraper/templates/servicemonitor.yaml
+++ b/promitor-agent-scraper/templates/servicemonitor.yaml
@@ -1,26 +1,26 @@
-{{- if and ( .Values.metricSinks.prometheusOperator.serviceMonitor.enabled ) (.Values.metricSinks.prometheusScrapingEndpoint.enabled ) }}
+{{- if and ( .Values.metricSinks.prometheusScrapingEndpoint.serviceMonitor.enabled ) (.Values.metricSinks.prometheusScrapingEndpoint.enabled ) }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-{{- if .Values.metricSinks.prometheusOperator.serviceMonitor.labels }}
+{{- if .Values.metricSinks.prometheusScrapingEndpoint.serviceMonitor.labels }}
   labels:
-{{ toYaml .Values.metricSinks.prometheusOperator.serviceMonitor.labels | indent 4 }}
+{{ toYaml .Values.metricSinks.prometheusScrapingEndpoint.serviceMonitor.labels | indent 4 }}
 {{- end }}
   name: {{ template "promitor-agent-scraper.fullname" . }}
-{{- if .Values.metricSinks.prometheusOperator.serviceMonitor.namespace }}
-  namespace: {{ .Values.metricSinks.prometheusOperator.serviceMonitor.namespace }}
+{{- if .Values.metricSinks.prometheusScrapingEndpoint.serviceMonitor.namespace }}
+  namespace: {{ .Values.metricSinks.prometheusScrapingEndpoint.serviceMonitor.namespace }}
 {{- end }}
 spec:
   endpoints:
   - targetPort: http
-{{- if .Values.metricSinks.prometheusOperator.serviceMonitor.interval }}
-    interval: {{ .Values.metricSinks.prometheusOperator.serviceMonitor.interval }}
+{{- if .Values.metricSinks.prometheusScrapingEndpoint.serviceMonitor.interval }}
+    interval: {{ .Values.metricSinks.prometheusScrapingEndpoint.serviceMonitor.interval }}
 {{- end }}
 {{- if .Values.metricSinks.prometheusScrapingEndpoint.baseUriPath }}
     path: {{ .Values.metricSinks.prometheusScrapingEndpoint.baseUriPath }}
 {{- end }}
-{{- if .Values.metricSinks.prometheusOperator.serviceMonitor.timeout }}
-    scrapeTimeout: {{ .Values.metricSinks.prometheusOperator.serviceMonitor.timeout }}
+{{- if .Values.metricSinks.prometheusScrapingEndpoint.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.metricSinks.prometheusScrapingEndpoint.serviceMonitor.timeout }}
 {{- end }}
   jobLabel: {{ template "promitor-agent-scraper.fullname" . }}
   namespaceSelector:

--- a/promitor-agent-scraper/templates/servicemonitor.yaml
+++ b/promitor-agent-scraper/templates/servicemonitor.yaml
@@ -2,8 +2,9 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-{{- if .Values.metricSinks.prometheusScrapingEndpoint.serviceMonitor.labels }}
   labels:
+{{- include "promitor-agent-scraper.labels" . | nindent 4 }}
+{{- if .Values.metricSinks.prometheusScrapingEndpoint.serviceMonitor.labels }}
 {{ toYaml .Values.metricSinks.prometheusScrapingEndpoint.serviceMonitor.labels | indent 4 }}
 {{- end }}
   name: {{ template "promitor-agent-scraper.fullname" . }}

--- a/promitor-agent-scraper/templates/servicemonitor.yaml
+++ b/promitor-agent-scraper/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{- if and ( .Values.metricSinks.prometheusOperator.serviceMonitor.enabled ) (.Values.metricSinks.prometheusScrapingEndpoint.enabled ) }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+{{- if .Values.metricSinks.prometheusOperator.serviceMonitor.labels }}
+  labels:
+{{ toYaml .Values.metricSinks.prometheusOperator.serviceMonitor.labels | indent 4 }}
+{{- end }}
+  name: {{ template "promitor-agent-scraper.fullname" . }}
+{{- if .Values.metricSinks.prometheusOperator.serviceMonitor.namespace }}
+  namespace: {{ .Values.metricSinks.prometheusOperator.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: http
+{{- if .Values.metricSinks.prometheusOperator.serviceMonitor.interval }}
+    interval: {{ .Values.metricSinks.prometheusOperator.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.metricSinks.prometheusScrapingEndpoint.baseUriPath }}
+    path: {{ .Values.metricSinks.prometheusScrapingEndpoint.baseUriPath }}
+{{- end }}
+{{- if .Values.metricSinks.prometheusOperator.serviceMonitor.timeout }}
+    scrapeTimeout: {{ .Values.metricSinks.prometheusOperator.serviceMonitor.timeout }}
+{{- end }}
+  jobLabel: {{ template "promitor-agent-scraper.fullname" . }}
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "promitor-agent-scraper.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -47,17 +47,16 @@ prometheusRule:
   rules: []
     # Sample rule below. Can also use templated strings with some limitations regarding possible line length: https://github.com/go-yaml/yaml/issues/166
     # To prevent Helm from messing up the rules on fields > 80 characters you can use yaml literal style as shown below.
-    # - alert: DemoMetricHigh
-    #   expr: |
-    #     my_metric{service="{{ template "promitor_agent_scraper.fullname" . }}"} > 10
-    #   for: 1m
-    #   labels:
-    #     severity: critical
-    #   annotations:
-    #     description: |
-    #       Service {{ template "promitor_agent_scraper.fullname" . }} currently reports {{ "{{ $value }}" }}
-    #     summary: |
-    #       my_metric value is {{ "{{ $value }}" }}
+    #  - alert: PromitorRemainingArmCalls
+    #    expr: |
+    #      promitor_ratelimit_arm{service="{{ template "promitor-agent-scraper.name" . }}"} < 11999
+    #    for: 5m
+    #    labels:
+    #      severity: warning
+    #    annotations:
+    #      description: |
+    #        Service {{ template "promitor-agent-scraper.name" . }} currently reports {{ "{{ $value }}" }} remaining calls before Azure Resource Manager throttles us.
+    #      summary: Azure Resource Manager may throttle us soon.
 resourceDiscovery:
   enabled: false
   host: ""

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -29,36 +29,35 @@ metricSinks:
     enableMetricTimestamps: true
     metricUnavailableValue: NaN
     enableServiceDiscovery: true
-  prometheusOperator:
     serviceMonitor:
       enabled: false
       namespace: ""
       labels: {}
       interval: 60s
       timeout: 10s
-    prometheusRule:
-      enabled: false
-      namespace: ""
-      additionalLabels: {}
-      rules: []
-        # Sample rule below. Can also use templated strings with some limitations regarding possible line length: https://github.com/go-yaml/yaml/issues/166
-        # To prevent Helm from messing up the rules on fields > 80 characters you can use yaml literal style as shown below.
-        # - alert: DemoMetricHigh
-        #   expr: |
-        #     my_metric{service="{{ template "promitor_agent_scraper.fullname" . }}"} > 10
-        #   for: 1m
-        #   labels:
-        #     severity: critical
-        #   annotations:
-        #     description: |
-        #       Service {{ template "promitor_agent_scraper.fullname" . }} currently reports {{ "{{ $value }}" }} 
-        #     summary: |
-        #       my_metric value is {{ "{{ $value }}" }}
   statsd:
     enabled: false
     host: ""
     port: 8125
     metricPrefix: ""
+prometheusRule:
+  enabled: false
+  namespace: ""
+  additionalLabels: {}
+  rules: []
+    # Sample rule below. Can also use templated strings with some limitations regarding possible line length: https://github.com/go-yaml/yaml/issues/166
+    # To prevent Helm from messing up the rules on fields > 80 characters you can use yaml literal style as shown below.
+    # - alert: DemoMetricHigh
+    #   expr: |
+    #     my_metric{service="{{ template "promitor_agent_scraper.fullname" . }}"} > 10
+    #   for: 1m
+    #   labels:
+    #     severity: critical
+    #   annotations:
+    #     description: |
+    #       Service {{ template "promitor_agent_scraper.fullname" . }} currently reports {{ "{{ $value }}" }} 
+    #     summary: |
+    #       my_metric value is {{ "{{ $value }}" }}
 resourceDiscovery:
   enabled: false
   host: ""

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -41,6 +41,19 @@ metricSinks:
       namespace: ""
       additionalLabels: {}
       rules: []
+        # Sample rule below. Can also use templated strings with some limitations regarding possible line length: https://github.com/go-yaml/yaml/issues/166
+        # To prevent Helm from messing up the rules on fields > 80 characters you can use yaml literal style as shown below.
+        # - alert: DemoMetricHigh
+        #   expr: |
+        #     my_metric{service="{{ template "promitor_agent_scraper.fullname" . }}"} > 10
+        #   for: 1m
+        #   labels:
+        #     severity: critical
+        #   annotations:
+        #     description: |
+        #       Service {{ template "promitor_agent_scraper.fullname" . }} currently reports {{ "{{ $value }}" }} 
+        #     summary: |
+        #       my_metric value is {{ "{{ $value }}" }}
   statsd:
     enabled: false
     host: ""

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -55,7 +55,7 @@ prometheusRule:
     #     severity: critical
     #   annotations:
     #     description: |
-    #       Service {{ template "promitor_agent_scraper.fullname" . }} currently reports {{ "{{ $value }}" }} 
+    #       Service {{ template "promitor_agent_scraper.fullname" . }} currently reports {{ "{{ $value }}" }}
     #     summary: |
     #       my_metric value is {{ "{{ $value }}" }}
 resourceDiscovery:

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -29,6 +29,18 @@ metricSinks:
     enableMetricTimestamps: true
     metricUnavailableValue: NaN
     enableServiceDiscovery: true
+  prometheusOperator:
+    serviceMonitor:
+      enabled: false
+      namespace: ""
+      labels: {}
+      interval: 60s
+      timeout: 10s
+    prometheusRule:
+      enabled: false
+      namespace: ""
+      additionalLabels: {}
+      rules: []
   statsd:
     enabled: false
     host: ""


### PR DESCRIPTION
Fixes #7 

This PR adds support for ServiceMonitor and PrometheusRule objects and some useful configuration options for both features.