### PR TITLE
fix: Helm fails to render the chart

### DIFF
--- a/promitor-agent-scraper/templates/prometheusrule.yaml
+++ b/promitor-agent-scraper/templates/prometheusrule.yaml
@@ -2,7 +2,7 @@
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
-  name: {{ template "promitor-agent-scraper" . }}
+  name: {{ template "promitor-agent-scraper.fullname" . }}
 {{- with .Values.prometheusRule.namespace }}
   namespace: {{ . }}
 {{- end }}


### PR DESCRIPTION
I tried to migrate my local installation to the upstream version today and ran into this issue. This happens when the PrometheusRule feature is enabled:
```
Error: malformed chart or values:
        templates/: template: promitor-agent-scraper/templates/prometheusrule.yaml:5:20: executing "promitor-agent-scraper/templates/prometheusrule.yaml" at <{{template "promitor-agent-scraper" .}}>: template "promitor-agent-scraper" not defined
```

Unfortunately I overlooked this little change. 
Sorry for the inconvenience 😢


Fixes #
