### PR TITLE
feat: Adding options to deploy Promitor with managed identity

### DIFF
--- a/promitor-agent-resource-discovery/README.md
+++ b/promitor-agent-resource-discovery/README.md
@@ -30,6 +30,7 @@ To install the chart with the release name `promitor-agent-resource-discovery`:
 
 ```console
 $ helm install promitor-agent-resource-discovery promitor/promitor-agent-resource-discovery \
+               --set azureAuthentication.identity.mode='ServicePrincipal' \
                --set azureAuthentication.identity.id='<azure-ad-app-id>' \
                --set azureAuthentication.identity.key='<azure-ad-app-key>' \
                --values /path/to/metric-declaration.yaml
@@ -117,6 +118,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to
 
 ```console
 $ helm install promitor-agent-resource-discovery promitor/promitor-agent-resource-discovery \
+               --set azureAuthentication.identity.mode='ServicePrincipal' \
                --set azureAuthentication.identity.id='<azure-ad-app-id>' \
                --set azureAuthentication.identity.key='<azure-ad-app-key>' \
                --set azureLandscape.tenantId='<azure-tenant-id>' \

--- a/promitor-agent-resource-discovery/README.md
+++ b/promitor-agent-resource-discovery/README.md
@@ -30,8 +30,8 @@ To install the chart with the release name `promitor-agent-resource-discovery`:
 
 ```console
 $ helm install promitor-agent-resource-discovery promitor/promitor-agent-resource-discovery \
-               --set azureAuthentication.appId='<azure-ad-app-id>' \
-               --set azureAuthentication.appKey='<azure-ad-app-key>' \
+               --set azureAuthentication.identity.id='<azure-ad-app-id>' \
+               --set azureAuthentication.identity.key='<azure-ad-app-key>' \
                --values /path/to/metric-declaration.yaml
 ```
 
@@ -63,8 +63,10 @@ their default values.
 | `azureLandscape.tenantId`  | Id of Azure tenant to discover resources in |             |
 | `azureLandscape.subscriptions`  | List of Azure subscription ids to discover resources in | `[]`            |
 | `resourceDiscoveryGroups`  | List of resource discovery groups to configured following the [resource discovery declaration docs](https://promitor.io/configuration/v2.x/resource-discovery) |        |
-| `azureAuthentication.appId`  | Id of the Azure AD entity to authenticate with |             |
-| `azureAuthentication.appKey`  | Secret of the Azure AD entity to authenticate with |             |
+| `azureAuthentication.mode`  | Authentication mode option for Azure authentication. Options are `ServicePrincipal` (default), `UserAssignedManagedIdentity` or `SystemAssignedManagedIdentity` |             |
+| `azureAuthentication.identity.id`  | Id of the Azure AD entity to authenticate with |             |
+| `azureAuthentication.identity.key`  | Secret of the Azure AD entity to authenticate with, when using mode `ServicePrincipal` (default) or `UserAssignedManagedIdentity` |             |
+| `azureAuthentication.identity.binding`  | Aad Pod Identity name, when using `UserAssignedManagedIdentity` or `SystemAssignedManagedIdentity` as mode |             |
 | `cache.enabled`  | Indication whether or not discovered resources should be cached in-memory to avoid Azure throttling | `true`            |
 | `cache.durationInMinutes`  | Amount of minutes to cache discovered resources | `5`            |
 | `telemetry.applicationInsights.enabled`  | Indication whether or not to send telemetry to Azure Application Insights | `false`            |
@@ -113,8 +115,8 @@ Specify each parameter using the `--set key=value[,key=value]` argument to
 
 ```console
 $ helm install promitor-agent-resource-discovery promitor/promitor-agent-resource-discovery \
-               --set azureAuthentication.appId='<azure-ad-app-id>' \
-               --set azureAuthentication.appKey='<azure-ad-app-key>' \
+               --set azureAuthentication.identity.id='<azure-ad-app-id>' \
+               --set azureAuthentication.identity.key='<azure-ad-app-key>' \
                --set azureLandscape.tenantId='<azure-tenant-id>' \
                --set azureLandscape.subscriptionId='<azure-subscription-id>' \
                --values C:\Promitor\metric-declaration.yaml

--- a/promitor-agent-resource-discovery/README.md
+++ b/promitor-agent-resource-discovery/README.md
@@ -63,6 +63,8 @@ their default values.
 | `azureLandscape.tenantId`  | Id of Azure tenant to discover resources in |             |
 | `azureLandscape.subscriptions`  | List of Azure subscription ids to discover resources in | `[]`            |
 | `resourceDiscoveryGroups`  | List of resource discovery groups to configured following the [resource discovery declaration docs](https://promitor.io/configuration/v2.x/resource-discovery) |        |
+| `azureAuthentication.appId`  | [Deprecated] Use `azureAuthentication.identity.id` instead |             |
+| `azureAuthentication.appKey`  | [Deprecated] Use `azureAuthentication.identity.key` instead |             |
 | `azureAuthentication.mode`  | Authentication mode option for Azure authentication. Options are `ServicePrincipal` (default), `UserAssignedManagedIdentity` or `SystemAssignedManagedIdentity` |             |
 | `azureAuthentication.identity.id`  | Id of the Azure AD entity to authenticate with |             |
 | `azureAuthentication.identity.key`  | Secret of the Azure AD entity to authenticate with, when using mode `ServicePrincipal` (default) or `UserAssignedManagedIdentity` |             |

--- a/promitor-agent-resource-discovery/templates/configmap.yaml
+++ b/promitor-agent-resource-discovery/templates/configmap.yaml
@@ -16,7 +16,7 @@ data:
         mode: {{ .Values.azureAuthentication.mode | default "servicePrincipal"}}
   {{- if .Values.azureAuthentication.identity.id }}
         identityId: {{ .Values.azureAuthentication.identity.id}}
-  {{- else if .Values.azureAuthentication.appId }}      
+  {{- else if .Values.azureAuthentication.appId }}
         identityId: {{ .Values.azureAuthentication.appId}}
   {{- end }}
       cache:

--- a/promitor-agent-resource-discovery/templates/configmap.yaml
+++ b/promitor-agent-resource-discovery/templates/configmap.yaml
@@ -16,6 +16,8 @@ data:
         mode: {{ .Values.azureAuthentication.mode | default "servicePrincipal"}}
   {{- if .Values.azureAuthentication.identity.id }}
         identityId: {{ .Values.azureAuthentication.identity.id}}
+  {{- else if .Values.azureAuthentication.appId }}      
+        identityId: {{ .Values.azureAuthentication.appId}}
   {{- end }}
       cache:
         enabled: {{ .Values.cache.enabled | quote }}

--- a/promitor-agent-resource-discovery/templates/configmap.yaml
+++ b/promitor-agent-resource-discovery/templates/configmap.yaml
@@ -12,6 +12,8 @@ data:
   runtime.yaml: |-
       server:
         httpPort: {{ .Values.service.targetPort | quote }}
+      authentication:
+        mode: {{ .Values.azureAuthentication.mode | default "servicePrincipal"}}
       cache:
         enabled: {{ .Values.cache.enabled | quote }}
         durationInMinutes: {{ .Values.cache.durationInMinutes | quote }}

--- a/promitor-agent-resource-discovery/templates/configmap.yaml
+++ b/promitor-agent-resource-discovery/templates/configmap.yaml
@@ -13,7 +13,7 @@ data:
       server:
         httpPort: {{ .Values.service.targetPort | quote }}
       authentication:
-        mode: {{ .Values.azureAuthentication.mode | default "servicePrincipal"}}
+        mode: {{ .Values.azureAuthentication.mode | default "ServicePrincipal"}}
   {{- if .Values.azureAuthentication.identity.id }}
         identityId: {{ .Values.azureAuthentication.identity.id}}
   {{- else if .Values.azureAuthentication.appId }}

--- a/promitor-agent-resource-discovery/templates/configmap.yaml
+++ b/promitor-agent-resource-discovery/templates/configmap.yaml
@@ -14,6 +14,9 @@ data:
         httpPort: {{ .Values.service.targetPort | quote }}
       authentication:
         mode: {{ .Values.azureAuthentication.mode | default "servicePrincipal"}}
+  {{- if .Values.azureAuthentication.identity.id }}
+        identityId: {{ .Values.azureAuthentication.identity.id}}
+  {{- end }}
       cache:
         enabled: {{ .Values.cache.enabled | quote }}
         durationInMinutes: {{ .Values.cache.durationInMinutes | quote }}

--- a/promitor-agent-resource-discovery/templates/deployment.yaml
+++ b/promitor-agent-resource-discovery/templates/deployment.yaml
@@ -53,7 +53,7 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-        {{- if .Values.azureAuthentication.identity.key }}
+        {{- if or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey}}
           env:
           - name: PROMITOR_AUTH_APPKEY
             valueFrom:

--- a/promitor-agent-resource-discovery/templates/deployment.yaml
+++ b/promitor-agent-resource-discovery/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       {{- if empty .Values.azureAuthentication.identity.binding | not }}
         aadpodidbinding: {{ .Values.azureAuthentication.identity.binding }}
-      {{- end }}      
+      {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.secrets.createSecret }}
@@ -60,7 +60,7 @@ spec:
               secretKeyRef:
                   name: {{ template "promitor-agent-resource-discovery.secretname" . }}
                   key: {{ .Values.secrets.appKeySecret }}
-        {{- end}}        
+        {{- end}}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/promitor-agent-resource-discovery/templates/deployment.yaml
+++ b/promitor-agent-resource-discovery/templates/deployment.yaml
@@ -22,8 +22,8 @@ spec:
       {{- if .Values.podLabels }}
       {{- toYaml .Values.podLabels | nindent 8 }}
       {{- end }}
-      {{- if empty .Values.azureAuthentication.aadpodidbinding | not }}
-        aadpodidbinding: {{ .Values.azureAuthentication.aadpodidbinding }}
+      {{- if empty .Values.azureAuthentication.identity.binding | not }}
+        aadpodidbinding: {{ .Values.azureAuthentication.identity.binding }}
       {{- end }}      
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
@@ -53,21 +53,8 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
+        {{- if .Values.azureAuthentication.identity.key }}
           env:
-        {{- if contains "managedIdentity" .Values.azureAuthentication.mode }}
-          {{- if empty .Values.azureAuthentication.managedIdentityId | not }} 
-          - name: PROMITOR_AUTH_UAMI
-            valueFrom:
-              secretKeyRef:
-                  name: {{ template "promitor-agent-resource-discovery.secretname" . }}
-                  key: {{ .Values.secrets.managedIdentityIdSecret }}
-          {{- end }}
-        {{- else }}
-          - name: PROMITOR_AUTH_APPID
-            valueFrom:
-              secretKeyRef:
-                  name: {{ template "promitor-agent-resource-discovery.secretname" . }}
-                  key: {{ .Values.secrets.appIdSecret }}
           - name: PROMITOR_AUTH_APPKEY
             valueFrom:
               secretKeyRef:

--- a/promitor-agent-resource-discovery/templates/deployment.yaml
+++ b/promitor-agent-resource-discovery/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       {{- if .Values.podLabels }}
       {{- toYaml .Values.podLabels | nindent 8 }}
       {{- end }}
+      {{- if empty .Values.azureAuthentication.aadpodidbinding | not }}
+        aadpodidbinding: {{ .Values.azureAuthentication.aadpodidbinding }}
+      {{- end }}      
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.secrets.createSecret }}
@@ -51,13 +54,26 @@ spec:
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           env:
+        {{- if contains "managedIdentity" .Values.azureAuthentication.mode }}
+          {{- if empty .Values.azureAuthentication.managedIdentityId | not }} 
+          - name: PROMITOR_AUTH_UAMI
+            valueFrom:
+              secretKeyRef:
+                  name: {{ template "promitor-agent-resource-discovery.secretname" . }}
+                  key: {{ .Values.secrets.managedIdentityIdSecret }}
+          {{- end }}
+        {{- else }}
           - name: PROMITOR_AUTH_APPID
-            value: {{ .Values.azureAuthentication.appId }}
+            valueFrom:
+              secretKeyRef:
+                  name: {{ template "promitor-agent-resource-discovery.secretname" . }}
+                  key: {{ .Values.secrets.appIdSecret }}
           - name: PROMITOR_AUTH_APPKEY
             valueFrom:
               secretKeyRef:
                   name: {{ template "promitor-agent-resource-discovery.secretname" . }}
                   key: {{ .Values.secrets.appKeySecret }}
+        {{- end}}        
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/promitor-agent-resource-discovery/templates/secret.yaml
+++ b/promitor-agent-resource-discovery/templates/secret.yaml
@@ -8,5 +8,12 @@ metadata:
     {{- include "promitor-agent-resource-discovery.labels" . | nindent 4 }}
 type: Opaque
 data:
+{{- if contains "managedIdentity" .Values.azureAuthentication.mode }}
+  {{- if empty .Values.azureAuthentication.managedIdentityId | not }} 
+  {{ .Values.secrets.managedIdentityIdSecret }}: {{ .Values.azureAuthentication.managedIdentityId | b64enc | quote }}
+  {{- end }}
+{{- else }}
+  {{ .Values.secrets.appIdSecret }}: {{ .Values.azureAuthentication.appId | b64enc | quote }}
   {{ .Values.secrets.appKeySecret }}: {{ .Values.azureAuthentication.appKey | b64enc | quote }}
+{{- end }}
 {{- end }}

--- a/promitor-agent-resource-discovery/templates/secret.yaml
+++ b/promitor-agent-resource-discovery/templates/secret.yaml
@@ -8,12 +8,5 @@ metadata:
     {{- include "promitor-agent-resource-discovery.labels" . | nindent 4 }}
 type: Opaque
 data:
-{{- if contains "managedIdentity" .Values.azureAuthentication.mode }}
-  {{- if empty .Values.azureAuthentication.managedIdentityId | not }} 
-  {{ .Values.secrets.managedIdentityIdSecret }}: {{ .Values.azureAuthentication.managedIdentityId | b64enc | quote }}
-  {{- end }}
-{{- else }}
-  {{ .Values.secrets.appIdSecret }}: {{ .Values.azureAuthentication.appId | b64enc | quote }}
-  {{ .Values.secrets.appKeySecret }}: {{ .Values.azureAuthentication.appKey | b64enc | quote }}
-{{- end }}
+  {{ .Values.secrets.appKeySecret  }}: {{ .Values.azureAuthentication.identity.key | b64enc | quote }}
 {{- end }}

--- a/promitor-agent-resource-discovery/templates/secret.yaml
+++ b/promitor-agent-resource-discovery/templates/secret.yaml
@@ -8,5 +8,9 @@ metadata:
     {{- include "promitor-agent-resource-discovery.labels" . | nindent 4 }}
 type: Opaque
 data:
+  {{- if .Values.azureAuthentication.identity.key}}
   {{ .Values.secrets.appKeySecret  }}: {{ .Values.azureAuthentication.identity.key | b64enc | quote }}
+  {{- else if .Values.azureAuthentication.appKey}}
+  {{ .Values.secrets.appKeySecret  }}: {{ .Values.azureAuthentication.appKey | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/promitor-agent-resource-discovery/values.yaml
+++ b/promitor-agent-resource-discovery/values.yaml
@@ -12,8 +12,11 @@ image:
   tag:
 
 azureAuthentication:
-  appId:
-  appKey:
+  appId: ""
+  appKey: ""
+  managedIdentityId: ""
+  mode: "servicePrincipal"
+  aadpodidbinding: ""
 cache:
   enabled: true
   durationInMinutes: 5
@@ -31,7 +34,7 @@ telemetry:
 ## Metric Declaration YAML
 azureLandscape:
   cloud: Global
-  tenantId:
+  tenantId: 
   subscriptions: []
   # This field is deprecated, use subscriptions instead please
   subscriptionIds: []
@@ -59,8 +62,10 @@ secrets:
   # To use your own secret, set createSecret to false and define the name/keys that your secret uses
   createSecret: true
   secretName: ""
+  appIdSecret: azure-app-id
   appKeySecret: azure-app-key
-
+  managedIdentityIdSecret: azure-managed-identity-id
+  
 service:
   port: 8889
   targetPort: 88

--- a/promitor-agent-resource-discovery/values.yaml
+++ b/promitor-agent-resource-discovery/values.yaml
@@ -63,7 +63,7 @@ secrets:
   createSecret: true
   secretName: ""
   appKeySecret: azure-app-key
-  
+
 service:
   port: 8889
   targetPort: 88

--- a/promitor-agent-resource-discovery/values.yaml
+++ b/promitor-agent-resource-discovery/values.yaml
@@ -34,7 +34,7 @@ telemetry:
 ## Metric Declaration YAML
 azureLandscape:
   cloud: Global
-  tenantId: 
+  tenantId:
   subscriptions: []
   # This field is deprecated, use subscriptions instead please
   subscriptionIds: []

--- a/promitor-agent-resource-discovery/values.yaml
+++ b/promitor-agent-resource-discovery/values.yaml
@@ -12,11 +12,11 @@ image:
   tag:
 
 azureAuthentication:
-  appId: ""
-  appKey: ""
-  managedIdentityId: ""
   mode: "servicePrincipal"
-  aadpodidbinding: ""
+  identity:
+    id: ""
+    key: ""
+    binding: ""
 cache:
   enabled: true
   durationInMinutes: 5
@@ -62,9 +62,7 @@ secrets:
   # To use your own secret, set createSecret to false and define the name/keys that your secret uses
   createSecret: true
   secretName: ""
-  appIdSecret: azure-app-id
   appKeySecret: azure-app-key
-  managedIdentityIdSecret: azure-managed-identity-id
   
 service:
   port: 8889

--- a/promitor-agent-resource-discovery/values.yaml
+++ b/promitor-agent-resource-discovery/values.yaml
@@ -12,6 +12,8 @@ image:
   tag:
 
 azureAuthentication:
+  appId: "" # [Deprecated] Prefer identity.id
+  appKey: "" # [Deprecated] Prefer identity.key
   mode: "servicePrincipal"
   identity:
     id: ""

--- a/promitor-agent-resource-discovery/values.yaml
+++ b/promitor-agent-resource-discovery/values.yaml
@@ -14,7 +14,7 @@ image:
 azureAuthentication:
   appId: "" # [Deprecated] Prefer identity.id
   appKey: "" # [Deprecated] Prefer identity.key
-  mode: "servicePrincipal"
+  mode: "ServicePrincipal"
   identity:
     id: ""
     key: ""

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -30,6 +30,7 @@ To install the chart with the release name `promitor-agent-scraper`:
 
 ```console
 $ helm install promitor-agent-scraper promitor/promitor-agent-scraper \
+               --set azureAuthentication.identity.mode='ServicePrincipal' \
                --set azureAuthentication.identity.id='<azure-ad-app-id>' \
                --set azureAuthentication.identity.key='<azure-ad-app-key>' \
                --values /path/to/metric-declaration.yaml
@@ -143,6 +144,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to
 
 ```console
 $ helm install promitor-agent-scraper promitor/promitor-agent-scraper \
+               --set azureAuthentication.identity.mode='ServicePrincipal' \
                --set azureAuthentication.identity.id='<azure-ad-app-id>' \
                --set azureAuthentication.identity.key='<azure-ad-app-key>' \
                --set azureMetadata.tenantId='<azure-tenant-id>' \

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -60,6 +60,8 @@ their default values.
 | `image.tag`  | Tag of image to use | None, chart app version is used by default            |
 | `image.pullPolicy`  | Policy to pull image | `Always`            |
 | `image.pullSecrets`  | ImagePullSecrets for the pod | `[]`            |
+| `azureAuthentication.appId`  | [Deprecated] Use `azureAuthentication.identity.id` instead |             |
+| `azureAuthentication.appKey`  | [Deprecated] User `azureAuthentication.identity.key` instead |             |
 | `azureAuthentication.mode`  | Authentication type to use to authenticate. Options are `ServicePrincipal` (default), `UserAssignedManagedIdentity` or `SystemAssignedManagedIdentity` |             |
 | `azureAuthentication.identity.id`  | Id of the Azure AD entity to authenticate with |             |
 | `azureAuthentication.identity.key`  | Secret of the Azure AD entity to authenticate with |             |

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -30,8 +30,8 @@ To install the chart with the release name `promitor-agent-scraper`:
 
 ```console
 $ helm install promitor-agent-scraper promitor/promitor-agent-scraper \
-               --set azureAuthentication.appId='<azure-ad-app-id>' \
-               --set azureAuthentication.appKey='<azure-ad-app-key>' \
+               --set azureAuthentication.identity.id='<azure-ad-app-id>' \
+               --set azureAuthentication.identity.key='<azure-ad-app-key>' \
                --values /path/to/metric-declaration.yaml
 ```
 
@@ -60,8 +60,10 @@ their default values.
 | `image.tag`  | Tag of image to use | None, chart app version is used by default            |
 | `image.pullPolicy`  | Policy to pull image | `Always`            |
 | `image.pullSecrets`  | ImagePullSecrets for the pod | `[]`            |
-| `azureAuthentication.appId`  | Id of the Azure AD entity to authenticate with |             |
-| `azureAuthentication.appKey`  | Secret of the Azure AD entity to authenticate with |             |
+| `azureAuthentication.mode`  | Authentication type to use to authenticate. Options are `ServicePrincipal` (default), `UserAssignedManagedIdentity` or `SystemAssignedManagedIdentity` |             |
+| `azureAuthentication.identity.id`  | Id of the Azure AD entity to authenticate with |             |
+| `azureAuthentication.identity.key`  | Secret of the Azure AD entity to authenticate with |             |
+| `azureAuthentication.identity.binding`  | Aad Pod Identity name, when using `UserAssignedManagedIdentity` or `SystemAssignedManagedIdentity` as mode |             |
 | `resourceDiscovery.enabled`  | Indication whether or not resource discovery is required | `false`            |
 | `resourceDiscovery.host`  | DNS name or IP address of the Promitor Resource Discovery agent |             |
 | `resourceDiscovery.port`  | Port (UDP) address of the Promitor Resource Discovery agent | `80`            |
@@ -127,7 +129,6 @@ their default values.
 | `tolerations` | Tolerations for pod assignment | `[]` |
 | `resources`  | Pod resource requests & limits |    `{}`    |
 | `secrets.createSecret`  | Indication if you want to bring your own secret level of logging | `true`            |
-| `secrets.appIdSecret`  | Name of the secret for Azure AD identity id | `azure-app-id`            |
 | `secrets.appKeySecret`  | Name of the secret for Azure AD identity secret | `azure-app-key`            |
 | `service.port`  | Port on service for other pods to talk to | `8888`            |
 | `service.targetPort`  | Port on container to serve traffic | `88`            |
@@ -140,8 +141,8 @@ Specify each parameter using the `--set key=value[,key=value]` argument to
 
 ```console
 $ helm install promitor-agent-scraper promitor/promitor-agent-scraper \
-               --set azureAuthentication.appId='<azure-ad-app-id>' \
-               --set azureAuthentication.appKey='<azure-ad-app-key>' \
+               --set azureAuthentication.identity.id='<azure-ad-app-id>' \
+               --set azureAuthentication.identity.key='<azure-ad-app-key>' \
                --set azureMetadata.tenantId='<azure-tenant-id>' \
                --set azureMetadata.subscriptionId='<azure-subscription-id>' \
                --values C:\Promitor\metric-declaration.yaml

--- a/promitor-agent-scraper/templates/configmap.yaml
+++ b/promitor-agent-scraper/templates/configmap.yaml
@@ -11,6 +11,8 @@ data:
   runtime.yaml: |-
       server:
         httpPort: {{ .Values.service.targetPort | quote }}
+      authentication:
+        mode: {{ .Values.azureAuthentication.mode | default "servicePrincipal"}}
   {{- if .Values.resourceDiscovery.enabled }}
       resourceDiscovery:
         host: {{ .Values.resourceDiscovery.host | quote }}

--- a/promitor-agent-scraper/templates/configmap.yaml
+++ b/promitor-agent-scraper/templates/configmap.yaml
@@ -13,6 +13,9 @@ data:
         httpPort: {{ .Values.service.targetPort | quote }}
       authentication:
         mode: {{ .Values.azureAuthentication.mode | default "servicePrincipal"}}
+  {{- if .Values.azureAuthentication.identity.id }}
+        identityId: {{ .Values.azureAuthentication.identity.id}}
+  {{- end }}        
   {{- if .Values.resourceDiscovery.enabled }}
       resourceDiscovery:
         host: {{ .Values.resourceDiscovery.host | quote }}

--- a/promitor-agent-scraper/templates/configmap.yaml
+++ b/promitor-agent-scraper/templates/configmap.yaml
@@ -12,7 +12,7 @@ data:
       server:
         httpPort: {{ .Values.service.targetPort | quote }}
       authentication:
-        mode: {{ .Values.azureAuthentication.mode | default "servicePrincipal"}}
+        mode: {{ .Values.azureAuthentication.mode | default "ServicePrincipal"}}
   {{- if .Values.azureAuthentication.identity.id }}
         identityId: {{ .Values.azureAuthentication.identity.id}}
   {{- else if .Values.azureAuthentication.appId }}

--- a/promitor-agent-scraper/templates/configmap.yaml
+++ b/promitor-agent-scraper/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
         mode: {{ .Values.azureAuthentication.mode | default "servicePrincipal"}}
   {{- if .Values.azureAuthentication.identity.id }}
         identityId: {{ .Values.azureAuthentication.identity.id}}
-  {{- end }}        
+  {{- end }}
   {{- if .Values.resourceDiscovery.enabled }}
       resourceDiscovery:
         host: {{ .Values.resourceDiscovery.host | quote }}

--- a/promitor-agent-scraper/templates/configmap.yaml
+++ b/promitor-agent-scraper/templates/configmap.yaml
@@ -15,6 +15,8 @@ data:
         mode: {{ .Values.azureAuthentication.mode | default "servicePrincipal"}}
   {{- if .Values.azureAuthentication.identity.id }}
         identityId: {{ .Values.azureAuthentication.identity.id}}
+  {{- else if .Values.azureAuthentication.appId }}      
+        identityId: {{ .Values.azureAuthentication.appId}}
   {{- end }}
   {{- if .Values.resourceDiscovery.enabled }}
       resourceDiscovery:

--- a/promitor-agent-scraper/templates/configmap.yaml
+++ b/promitor-agent-scraper/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
         mode: {{ .Values.azureAuthentication.mode | default "servicePrincipal"}}
   {{- if .Values.azureAuthentication.identity.id }}
         identityId: {{ .Values.azureAuthentication.identity.id}}
-  {{- else if .Values.azureAuthentication.appId }}      
+  {{- else if .Values.azureAuthentication.appId }}
         identityId: {{ .Values.azureAuthentication.appId}}
   {{- end }}
   {{- if .Values.resourceDiscovery.enabled }}

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
       {{- end }}
       {{- if empty .Values.azureAuthentication.identity.binding | not }}
         aadpodidbinding: {{ .Values.azureAuthentication.identity.binding }}
-      {{- end }}      
+      {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.secrets.createSecret }}

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -22,9 +22,9 @@ spec:
       {{- if .Values.podLabels }}
       {{- toYaml .Values.podLabels | nindent 8 }}
       {{- end }}
-      {{- if empty .Values.azureAuthentication.aadpodidbinding | not }}
-        aadpodidbinding: {{ .Values.azureAuthentication.aadpodidbinding }}
-      {{- end }}
+      {{- if empty .Values.azureAuthentication.identity.binding | not }}
+        aadpodidbinding: {{ .Values.azureAuthentication.identity.binding }}
+      {{- end }}      
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.secrets.createSecret }}
@@ -58,26 +58,13 @@ spec:
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           env:
-        {{- if contains "managedIdentity" .Values.azureAuthentication.mode }}
-          {{- if empty .Values.azureAuthentication.managedIdentityId | not }} 
-          - name: PROMITOR_AUTH_UAMI
-            valueFrom:
-              secretKeyRef:
-                  name: {{ template "promitor-agent-scraper.secretname" . }}
-                  key: {{ .Values.secrets.managedIdentityIdSecret }}
-          {{- end }}
-        {{- else }}
-          - name: PROMITOR_AUTH_APPID
-            valueFrom:
-              secretKeyRef:
-                  name: {{ template "promitor-agent-scraper.secretname" . }}
-                  key: {{ .Values.secrets.appIdSecret }}
+  {{- if .Values.azureAuthentication.identity.key }}
           - name: PROMITOR_AUTH_APPKEY
             valueFrom:
               secretKeyRef:
                   name: {{ template "promitor-agent-scraper.secretname" . }}
                   key: {{ .Values.secrets.appKeySecret }}
-        {{- end}}        
+  {{- end}}        
   {{- if .Values.metricSinks.atlassianStatuspage.apiKey }}
           - name: PROMITOR_ATLASSIAN_STATUSPAGE_APIKEY
             valueFrom:

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -58,7 +58,7 @@ spec:
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           env:
-  {{- if .Values.azureAuthentication.identity.key }}
+  {{- if or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey }}
           - name: PROMITOR_AUTH_APPKEY
             valueFrom:
               secretKeyRef:

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
               secretKeyRef:
                   name: {{ template "promitor-agent-scraper.secretname" . }}
                   key: {{ .Values.secrets.appKeySecret }}
-  {{- end}}        
+  {{- end}}
   {{- if .Values.metricSinks.atlassianStatuspage.apiKey }}
           - name: PROMITOR_ATLASSIAN_STATUSPAGE_APIKEY
             valueFrom:

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
       {{- if .Values.podLabels }}
       {{- toYaml .Values.podLabels | nindent 8 }}
       {{- end }}
+      {{- if empty .Values.azureAuthentication.aadpodidbinding | not }}
+        aadpodidbinding: {{ .Values.azureAuthentication.aadpodidbinding }}
+      {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- if .Values.secrets.createSecret }}
@@ -55,6 +58,15 @@ spec:
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
           env:
+        {{- if contains "managedIdentity" .Values.azureAuthentication.mode }}
+          {{- if empty .Values.azureAuthentication.managedIdentityId | not }} 
+          - name: PROMITOR_AUTH_UAMI
+            valueFrom:
+              secretKeyRef:
+                  name: {{ template "promitor-agent-scraper.secretname" . }}
+                  key: {{ .Values.secrets.managedIdentityIdSecret }}
+          {{- end }}
+        {{- else }}
           - name: PROMITOR_AUTH_APPID
             valueFrom:
               secretKeyRef:
@@ -65,6 +77,7 @@ spec:
               secretKeyRef:
                   name: {{ template "promitor-agent-scraper.secretname" . }}
                   key: {{ .Values.secrets.appKeySecret }}
+        {{- end}}        
   {{- if .Values.metricSinks.atlassianStatuspage.apiKey }}
           - name: PROMITOR_ATLASSIAN_STATUSPAGE_APIKEY
             valueFrom:

--- a/promitor-agent-scraper/templates/secret.yaml
+++ b/promitor-agent-scraper/templates/secret.yaml
@@ -8,7 +8,11 @@ metadata:
     {{- include "promitor-agent-scraper.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{ .Values.secrets.appKeySecret }}: {{ .Values.azureAuthentication.identity.key | b64enc | quote }}
+  {{- if .Values.azureAuthentication.identity.key}}
+  {{ .Values.secrets.appKeySecret  }}: {{ .Values.azureAuthentication.identity.key | b64enc | quote }}
+  {{- else if .Values.azureAuthentication.appKey}}
+  {{ .Values.secrets.appKeySecret  }}: {{ .Values.azureAuthentication.appKey | b64enc | quote }}
+  {{- end }}
   {{- if .Values.metricSinks.atlassianStatuspage.apiKey }}
   {{ .Values.secrets.atlassianStatuspageApiKey }}: {{ .Values.metricSinks.atlassianStatuspage.apiKey | b64enc | quote }}
   {{- end }}

--- a/promitor-agent-scraper/templates/secret.yaml
+++ b/promitor-agent-scraper/templates/secret.yaml
@@ -8,9 +8,16 @@ metadata:
     {{- include "promitor-agent-scraper.labels" . | nindent 4 }}
 type: Opaque
 data:
+{{- if contains "managedIdentity" .Values.azureAuthentication.mode }}
+  {{- if empty .Values.azureAuthentication.managedIdentityId | not }} 
+  {{ .Values.secrets.managedIdentityIdSecret }}: {{ .Values.azureAuthentication.managedIdentityId | b64enc | quote }}
+  {{- end }}
+{{- else }}
   {{ .Values.secrets.appIdSecret }}: {{ .Values.azureAuthentication.appId | b64enc | quote }}
   {{ .Values.secrets.appKeySecret }}: {{ .Values.azureAuthentication.appKey | b64enc | quote }}
-  {{- if .Values.metricSinks.atlassianStatuspage.apiKey }}
+{{- end }}
+
+{{- if .Values.metricSinks.atlassianStatuspage.apiKey }}
   {{ .Values.secrets.atlassianStatuspageApiKey }}: {{ .Values.metricSinks.atlassianStatuspage.apiKey | b64enc | quote }}
-  {{- end }}
+{{- end }}
 {{- end }}

--- a/promitor-agent-scraper/templates/secret.yaml
+++ b/promitor-agent-scraper/templates/secret.yaml
@@ -8,16 +8,8 @@ metadata:
     {{- include "promitor-agent-scraper.labels" . | nindent 4 }}
 type: Opaque
 data:
-{{- if contains "managedIdentity" .Values.azureAuthentication.mode }}
-  {{- if empty .Values.azureAuthentication.managedIdentityId | not }} 
-  {{ .Values.secrets.managedIdentityIdSecret }}: {{ .Values.azureAuthentication.managedIdentityId | b64enc | quote }}
-  {{- end }}
-{{- else }}
-  {{ .Values.secrets.appIdSecret }}: {{ .Values.azureAuthentication.appId | b64enc | quote }}
-  {{ .Values.secrets.appKeySecret }}: {{ .Values.azureAuthentication.appKey | b64enc | quote }}
-{{- end }}
-
-{{- if .Values.metricSinks.atlassianStatuspage.apiKey }}
+  {{ .Values.secrets.appKeySecret }}: {{ .Values.azureAuthentication.identity.key | b64enc | quote }}
+  {{- if .Values.metricSinks.atlassianStatuspage.apiKey }}
   {{ .Values.secrets.atlassianStatuspageApiKey }}: {{ .Values.metricSinks.atlassianStatuspage.apiKey | b64enc | quote }}
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -13,6 +13,8 @@ image:
   tag:
 
 azureAuthentication:
+  appId: "" # [Deprecated] Prefer identity.id
+  appKey: "" # [Deprecated] Prefer identity.key
   mode: "servicePrincipal"
   identity:
     id: ""

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -13,11 +13,11 @@ image:
   tag:
 
 azureAuthentication:
-  appId: ""
-  appKey: ""
-  managedIdentityId: ""
   mode: "servicePrincipal"
-  aadpodidbinding: ""
+  identity:
+    id: ""
+    key: ""
+    binding: ""
 metricSinks:
   atlassianStatuspage:
     enabled: false
@@ -102,8 +102,6 @@ secrets:
   # To use your own secret, set createSecret to false and define the name/keys that your secret uses
   createSecret: true
   secretName: ""
-  managedIdentityIdSecret: azure-managed-identity-id
-  appIdSecret: azure-app-id
   appKeySecret: azure-app-key
   atlassianStatuspageApiKey: atlassian-statuspage-apikey
 

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -15,7 +15,7 @@ image:
 azureAuthentication:
   appId: "" # [Deprecated] Prefer identity.id
   appKey: "" # [Deprecated] Prefer identity.key
-  mode: "servicePrincipal"
+  mode: "ServicePrincipal"
   identity:
     id: ""
     key: ""

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -15,6 +15,9 @@ image:
 azureAuthentication:
   appId: ""
   appKey: ""
+  managedIdentityId: ""
+  mode: "servicePrincipal"
+  aadpodidbinding: ""
 metricSinks:
   atlassianStatuspage:
     enabled: false
@@ -99,6 +102,7 @@ secrets:
   # To use your own secret, set createSecret to false and define the name/keys that your secret uses
   createSecret: true
   secretName: ""
+  managedIdentityIdSecret: azure-managed-identity-id
   appIdSecret: azure-app-id
   appKeySecret: azure-app-key
   atlassianStatuspageApiKey: atlassian-statuspage-apikey


### PR DESCRIPTION
# Adding options to authenticate Promitor using Managed Identity

> **[Update 1/4/2021]: Update yaml examples to the last PR commit**

Update of the charts (**Scraper** and **Resource-Discovery**) to allow user to authenticate **Promitor** with **Managed Identity**.

Basically, in both charts, `values.yaml`, `configmap.yaml`, `deployment.yaml`, and `secret.yaml` have been updated.

From a user perspective, here is a sample of a `values.yaml` that can be submitted:

Using a **Service Principal**:
``` yaml
azureAuthentication:
  mode: "ServicePrincipal"
  identity:
     id: "xxxxxxxx-xxxxx-xxxxxx-xxxxxx"
     key: "xxxxxxxx-xxxxx-xxxxxx-xxxxxx"
```

Using a **Service Managed Identity** (with aad pod indentity already deployed in the aks cluster):
``` yaml
azureAuthentication:
  mode: "SystemAssignedManagedIdentity"
  identity:
     binding: "aadpodid1"
```

Using a **User Managed Identity**:
``` yaml
azureAuthentication:
  mode: "UserAssignedManagedIdentity"
  identity:
     id: "xxxxxxxx-xxxxx-xxxxxx-xxxxxx"
     key: "xxxxxxxx-xxxxx-xxxxxx-xxxxxx"
     binding: "aadpodid1"
```

*Note* : 
- If `mode` is not specified, the `servicePrincipal` value is used by default.
- If `identity.key` is omitted (and needed when mode is `UserAssignedManagedIdentity` or `ServicePrincipal`), the environment variable `PROMITOR_AUTH_APPKEY` is used
