### PR TITLE
feat: Support specifying cloud for Promitor Scraper

### DIFF
--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -101,6 +101,7 @@ their default values.
 | `azureMetadata.tenantId`  | Id of Azure tenant |             |
 | `azureMetadata.subscriptionId`  | Id of Azure subscription |             |
 | `azureMetadata.resourceGroupName`  | Name of resource group | `promitor`            |
+| `azureMetadata.cloud`  | Azure Cloud to authenticated and scraping metrics from. Options are Global (default), China, UsGov & Germany | `Global`            |
 | `metricDefaults.aggregation.interval`  | Default interval which defines over what period measurements of a metric should be aggregated | `00:05:00`            |
 | `metricDefaults.scraping.schedule`  | Cron expression that controls the fequency in which all the configured metrics will be scraped from Azure Monitor | `*/5 * * * *`            |
 | `metrics`  | List of metrics to scrape configured following the [metric declaration docs](https://promitor.io/configuration/metrics/) |        |

--- a/promitor-agent-scraper/templates/configmap.yaml
+++ b/promitor-agent-scraper/templates/configmap.yaml
@@ -69,6 +69,7 @@ data:
       tenantId: {{ .Values.azureMetadata.tenantId }}
       subscriptionId: {{ .Values.azureMetadata.subscriptionId }}
       resourceGroupName: {{ .Values.azureMetadata.resourceGroupName }}
+      cloud: {{ .Values.azureMetadata.cloud }}
     metricDefaults:
       aggregation:
         interval: {{ .Values.metricDefaults.aggregation.interval }}

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -81,6 +81,7 @@ azureMetadata:
   tenantId: ""
   subscriptionId: ""
   resourceGroupName: promitor
+  cloud: "Global"
 metricDefaults:
   aggregation:
     interval: 00:05:00


### PR DESCRIPTION
Follow up the authentication issue for Azure Us Gov cloud and the https://github.com/tomkerkhove/promitor/pull/1648 , I found that we missed this in our chart.