### PR TITLE
feat: Expose configuration for transformation of metric labels

### DIFF
--- a/promitor-agent-scraper/templates/configmap.yaml
+++ b/promitor-agent-scraper/templates/configmap.yaml
@@ -39,6 +39,8 @@ data:
           metricUnavailableValue: {{ .Values.metricSinks.prometheusScrapingEndpoint.metricUnavailableValue | quote }}
           enableMetricTimestamps: {{ .Values.metricSinks.prometheusScrapingEndpoint.enableMetricTimestamps | quote }}
           baseUriPath: {{ .Values.metricSinks.prometheusScrapingEndpoint.baseUriPath | quote }}
+          labels:
+            transformation: {{ .Values.metricSinks.prometheusScrapingEndpoint.labelTransformation | quote }}
   {{- end }}
   {{- if .Values.metricSinks.atlassianStatuspage.enabled }}
         atlassianStatuspage:

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -33,6 +33,7 @@ metricSinks:
     baseUriPath: /metrics
     enableMetricTimestamps: true
     metricUnavailableValue: NaN
+    labelTransformation: None
     enableServiceDiscovery: true
     serviceMonitor:
       enabled: false


### PR DESCRIPTION
Added a Helm config parameter for the runtime parameter "metricSinks.prometheusScrapingEndpoint.labels.transformation". I flattened the parameter name in the values.yaml to "labelTransformation", because 
```
labels:
  transformation: ...
```
could be confusing. Most Helm users certainly expect that a "labels" key is used for setting labels on k8s object, but this is not the case here.
I'm not sold on this idea. Let me know what you think.

Relates to https://github.com/tomkerkhove/promitor/pull/1606