### PR TITLE
feat: Provide secure-by-default for Promitor Scraper agent

### DIFF
--- a/promitor-agent-scraper/Chart.yaml
+++ b/promitor-agent-scraper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.6.1
+version: 2.7.0
 appVersion: 2.5.1
 type: application
 name: promitor-agent-scraper

--- a/promitor-agent-scraper/Chart.yaml
+++ b/promitor-agent-scraper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.7.0
+version: 2.6.1
 appVersion: 2.5.1
 type: application
 name: promitor-agent-scraper

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -112,6 +112,7 @@ their default values.
 | `rbac.serviceAccount.create` | Create service account resource | `true` |
 | `rbac.serviceAccount.name` | Service account name to use if create is false. If create is true, a name is generated using the fullname template | `promitor-scraper` |
 | `rbac.serviceAccount.annotations` | Service account annotations| `{}` |
+| `rbac.serviceAccount.automountServiceAccountToken` | If service account token should be mounted inside pod| `false` |
 | `health.readiness.enabled`  | Indication if readiness probes should be used | `true`            |   |
 | `health.readiness.verifyDependencies`  | Indication if readiness probes should verify if Promitor can interat with external dependencies. Do note that this will contact all dependencies which can have performance impact, cause throttling or cascading failures when consumed very often. | `false`            |   |
 | `health.readiness.delay`  | Amount of seconds to wait before probing the container to verify if it's ready | `5` |
@@ -130,14 +131,16 @@ their default values.
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `podLabels`  | Additional pod labels to include |    `{}`    |
 | `priorityClassName`  | Priority class to be used by pod ([docs](https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/)) |    `""`    |
-| `securityContext.*`  | Custom security context object for pod ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)) | `{}`            |
-| `securityContext.enabled`  | Whether to include custom security context for pod or not | `false`            |
+| `securityContext.enabled`  | Whether to include custom security context for pod or not | `true`            |
+| `securityContext.*`  | Custom security context object for pod ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)) | <pre>runAsGroup: 10000<br>runAsNonRoot: true<br>runAsUser: 10000<br>seccompProfile:<br>&emsp;type: RuntimeDefault</pre> |
+| `containerSecurityContext.enabled`  | Whether to include custom security context for container or not | `true`            |
+| `containerSecurityContext.*`  | Custom security context object for container ([docs](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container)) | <pre>allowPrivilegeEscalation: false<br>capabilities:<br>&emsp;drop:<br>&emsp;- ALL<br>privileged: false<br>readOnlyRootFilesystem: true</pre> |
 | `tolerations` | Tolerations for pod assignment | `[]` |
 | `resources`  | Pod resource requests & limits |    `{}`    |
 | `secrets.createSecret`  | Indication if you want to bring your own secret level of logging | `true`            |
 | `secrets.appKeySecret`  | Name of the secret for Azure AD identity secret | `azure-app-key`            |
 | `service.port`  | Port on service for other pods to talk to | `8888`            |
-| `service.targetPort`  | Port on container to serve traffic | `88`            |
+| `service.targetPort`  | Port on container to serve traffic | `5000`            |
 | `service.loadbalancer.enabled`  | Indication whether or not to expose service externally through a load balancer | `false`            |
 | `service.loadbalancer.azure.dnsPrefix`  | **[Azure Kubernetes Service only]** Prefix for DNS name to expose the service on using `<name>.<location>.cloudapp.azure.com` format. ([docs](https://docs.microsoft.com/en-us/azure/aks/static-ip#apply-a-dns-label-to-the-service)) | ``            |
 | `service.loadbalancer.azure.exposeInternally`  | To restrict access to Promitor by exposing it through an internal load balancer. This setting is specific to Azure Kubernetes Service ([docs](https://docs.microsoft.com/en-us/azure/aks/internal-lb)) | `false`            |

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -31,6 +31,9 @@ spec:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
     spec:
+      {{- if .Values.rbac.serviceAccount.automountServiceAccountToken }}
+      automountServiceAccountToken: true
+      {{- end }}
       {{- if .Values.securityContext.enabled }}
       securityContext: {{- omit .Values.securityContext "enabled" | toYaml | nindent 8 }}
       {{- end }}

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -31,7 +31,7 @@ spec:
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
     spec:
-      {{- if .Values.rbac.serviceAccount.automountServiceAccountToken }}
+      {{- if and .Values.rbac.create .Values.rbac.serviceAccount.create .Values.rbac.serviceAccount.automountServiceAccountToken }}
       automountServiceAccountToken: true
       {{- end }}
       {{- if .Values.securityContext.enabled }}

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -77,9 +77,16 @@ spec:
   {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- if .Values.containerSecurityContext.enabled }}
+          securityContext: {{- omit .Values.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          {{- end }}
           volumeMounts:
           - name: config-volume-{{ template "promitor-agent-scraper.name" . }}
             mountPath: /config/
+          {{- if and .Values.containerSecurityContext.enabled .Values.containerSecurityContext.readOnlyRootFilesystem }}
+          - name: tmp
+            mountPath: /tmp/
+          {{- end }}
   {{- if .Values.health.liveness.enabled }}
           livenessProbe:
             failureThreshold: {{ .Values.health.liveness.thresholds.failure }}
@@ -112,3 +119,7 @@ spec:
         - name: config-volume-{{ template "promitor-agent-scraper.name" . }}
           configMap:
             name: config-map-{{ template "promitor-agent-scraper.name" . }}
+        {{- if and .Values.containerSecurityContext.enabled .Values.containerSecurityContext.readOnlyRootFilesystem }}
+        - emptyDir: {}
+          name: tmp
+        {{- end }}

--- a/promitor-agent-scraper/templates/serviceaccount.yaml
+++ b/promitor-agent-scraper/templates/serviceaccount.yaml
@@ -1,5 +1,6 @@
 {{- if and .Values.rbac.create .Values.rbac.serviceAccount.create -}}
 apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   name: {{ template "promitor-agent-scraper.serviceaccountname" . }}

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -175,6 +175,10 @@ rbac:
     name: promitor-scraper
     annotations: {}
 
+    ## If true will mount service account token.
+    ## Set this to true if you plan on using Pod Security Policy
+    automountServiceAccountToken: false
+
 nodeSelector: {}
 
 securityContext:

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -113,7 +113,7 @@ secrets:
 
 service:
   port: 8888
-  targetPort: 88
+  targetPort: 5000
   loadBalancer:
     enabled: false
     azure:

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -113,6 +113,8 @@ secrets:
 
 service:
   port: 8888
+  ## By default this pod is running as a non-root user.
+  ## If you choose targetPort <1024 it will fail to start.
   targetPort: 5000
   loadBalancer:
     enabled: false
@@ -181,7 +183,23 @@ rbac:
 
 nodeSelector: {}
 
+## securityContext and containerSecurityContext are using secure defaults.
+## Only override if you have a good reason to.
 securityContext:
-  enabled: false
+  enabled: true
+  runAsGroup: 10000
+  runAsNonRoot: true
+  runAsUser: 10000
+  seccompProfile:
+    type: RuntimeDefault
+
+containerSecurityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
+  enabled: true
+  privileged: false
+  readOnlyRootFilesystem: true
 
 tolerations: []

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -177,7 +177,6 @@ rbac:
     name: promitor-scraper
     annotations: {}
 
-    ## If true will mount service account token.
     ## Set this to true if you plan on using Pod Security Policy
     automountServiceAccountToken: false
 


### PR DESCRIPTION
Everything we're discussed in https://github.com/promitor/charts/issues/69 plus service account token is mounted at the pod level. By default it's not being mounted at all. This can be changed from values.yaml.
