### PR TITLE
fix: add emptyDir to PSP

### DIFF
--- a/promitor-agent-scraper/templates/podsecuritypolicy.yaml
+++ b/promitor-agent-scraper/templates/podsecuritypolicy.yaml
@@ -14,6 +14,7 @@ spec:
   volumes:
     - configMap
     - secret
+    - emptyDir
   hostNetwork: false
   hostIPC: false
   hostPID: false


### PR DESCRIPTION
PSP is missing emptyDir referenced in deployment


Fixes #
