### PR TITLE
feat: upgrade role/rolebinding apiVersion and keep backward compatibility

### DIFF
--- a/promitor-agent-resource-discovery/Chart.yaml
+++ b/promitor-agent-resource-discovery/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 0.7.0
+version: 0.7.1
 appVersion: 0.7.0
 type: application
 name: promitor-agent-resource-discovery

--- a/promitor-agent-resource-discovery/templates/role.yaml
+++ b/promitor-agent-resource-discovery/templates/role.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.rbac.create .Values.rbac.podSecurityPolicyEnabled }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 kind: Role
 metadata:
   name: {{ template "promitor-agent-resource-discovery.name" . }}

--- a/promitor-agent-resource-discovery/templates/rolebinding.yaml
+++ b/promitor-agent-resource-discovery/templates/rolebinding.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.rbac.create .Values.rbac.podSecurityPolicyEnabled }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 kind: RoleBinding
 metadata:
   name: {{ template "promitor-agent-resource-discovery.name" . }}

--- a/promitor-agent-scraper/Chart.yaml
+++ b/promitor-agent-scraper/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 2.7.0
+version: 2.7.1
 appVersion: 2.6.0
 type: application
 name: promitor-agent-scraper

--- a/promitor-agent-scraper/templates/role.yaml
+++ b/promitor-agent-scraper/templates/role.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.rbac.create .Values.rbac.podSecurityPolicyEnabled }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 kind: Role
 metadata:
   name: {{ template "promitor-agent-scraper.name" . }}

--- a/promitor-agent-scraper/templates/rolebinding.yaml
+++ b/promitor-agent-scraper/templates/rolebinding.yaml
@@ -1,5 +1,9 @@
 {{- if and .Values.rbac.create .Values.rbac.podSecurityPolicyEnabled }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" }}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 kind: RoleBinding
 metadata:
   name: {{ template "promitor-agent-scraper.name" . }}


### PR DESCRIPTION
`rbac.authorization.k8s.io/v1beta1` has been removed since kubernetes v1.22.