### PR TITLE
feat: Provide capability to bring custom environment variables & secrets

### DIFF
--- a/promitor-agent-resource-discovery/README.md
+++ b/promitor-agent-resource-discovery/README.md
@@ -117,6 +117,7 @@ their default values.
 | `resources`  | Pod resource requests & limits |    `{}`    |
 | `secrets.createSecret`  | Indication if you want to bring your own secret level of logging | `true`            |   |
 | `secrets.appKeySecret`  | Name of the secret for Azure AD identity secret | `azure-app-key`            |
+| `secrets.extra`  | Add extra secrets | `{}` |
 | `service.loadbalancer.enabled`  | Indication whether or not to expose service externally through a load balancer | `false`            |
 | `service.loadbalancer.azure.dnsPrefix`  | Prefix for DNS name to expose the service on using `<name>.<location>.cloudapp.azure.com` format. This setting is specific to Azure Kubernetes Service ([docs](https://docs.microsoft.com/en-us/azure/aks/static-ip#apply-a-dns-label-to-the-service)) | ``            |
 | `service.loadbalancer.azure.exposeInternally`  | To restrict access to Promitor by exposing it through an internal load balancer. This setting is specific to Azure Kubernetes Service ([docs](https://docs.microsoft.com/en-us/azure/aks/internal-lb)) | `false`            |

--- a/promitor-agent-resource-discovery/README.md
+++ b/promitor-agent-resource-discovery/README.md
@@ -123,7 +123,7 @@ their default values.
 | `service.loadbalancer.azure.exposeInternally`  | To restrict access to Promitor by exposing it through an internal load balancer. This setting is specific to Azure Kubernetes Service ([docs](https://docs.microsoft.com/en-us/azure/aks/internal-lb)) | `false`            |
 | `service.port`  | Port on service for other pods to talk to | `8889`            |
 | `service.targetPort`  | Port on container to serve traffic | `88`            |
-| `deployment.extraEnv`  | Add extra environment variables to the promitor deployment | `[]` |
+| `deployment.env.extra`  | Add extra environment variables to the promitor deployment | `[]` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`. For example:

--- a/promitor-agent-resource-discovery/README.md
+++ b/promitor-agent-resource-discovery/README.md
@@ -122,6 +122,7 @@ their default values.
 | `service.loadbalancer.azure.exposeInternally`  | To restrict access to Promitor by exposing it through an internal load balancer. This setting is specific to Azure Kubernetes Service ([docs](https://docs.microsoft.com/en-us/azure/aks/internal-lb)) | `false`            |
 | `service.port`  | Port on service for other pods to talk to | `8889`            |
 | `service.targetPort`  | Port on container to serve traffic | `88`            |
+| `deployment.extraEnv`  | Add extra environment variables to the promitor deployment | `[]` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`. For example:

--- a/promitor-agent-resource-discovery/templates/deployment.yaml
+++ b/promitor-agent-resource-discovery/templates/deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-        {{- if or (or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey) .Values.deployment.extraEnv }}
+        {{- if or (or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey) .Values.deployment.env.extra }}
           env:
         {{- if or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey}}
           - name: PROMITOR_AUTH_APPKEY
@@ -65,8 +65,8 @@ spec:
                   name: {{ template "promitor-agent-resource-discovery.secretname" . }}
                   key: {{ .Values.secrets.appKeySecret }}
         {{- end }}
-        {{- if .Values.deployment.extraEnv }}
-{{ toYaml .Values.deployment.extraEnv | indent 12 }}
+        {{- if .Values.deployment.env.extra }}
+{{ toYaml .Values.deployment.env.extra | indent 12 }}
         {{- end }}
         {{- end }}
           resources:

--- a/promitor-agent-resource-discovery/templates/deployment.yaml
+++ b/promitor-agent-resource-discovery/templates/deployment.yaml
@@ -56,14 +56,19 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-        {{- if or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey}}
+        {{- if or (or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey) .Values.deployment.extraEnv }}
           env:
+        {{- if or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey}}
           - name: PROMITOR_AUTH_APPKEY
             valueFrom:
               secretKeyRef:
                   name: {{ template "promitor-agent-resource-discovery.secretname" . }}
                   key: {{ .Values.secrets.appKeySecret }}
-        {{- end}}
+        {{- end }}
+        {{- if .Values.deployment.extraEnv }}
+{{ toYaml .Values.deployment.extraEnv | indent 12 }}
+        {{- end }}
+        {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           volumeMounts:

--- a/promitor-agent-resource-discovery/templates/secret.yaml
+++ b/promitor-agent-resource-discovery/templates/secret.yaml
@@ -13,4 +13,7 @@ data:
   {{- else if .Values.azureAuthentication.appKey}}
   {{ .Values.secrets.appKeySecret  }}: {{ .Values.azureAuthentication.appKey | b64enc | quote }}
   {{- end }}
+  {{- range $key, $value := .Values.secrets.extra }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/promitor-agent-resource-discovery/values.yaml
+++ b/promitor-agent-resource-discovery/values.yaml
@@ -71,6 +71,14 @@ resourceDiscoveryGroups: []
 #       - northeurope
 #       - westeurope
 
+deployment:
+  extraEnv: []
+  # - name: AZURE_STORAGE_QUEUE_SAS_TOKEN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: azure-storage-queue
+  #       key: sas-token
+
 secrets:
   # To use your own secret, set createSecret to false and define the name/keys that your secret uses
   createSecret: true

--- a/promitor-agent-resource-discovery/values.yaml
+++ b/promitor-agent-resource-discovery/values.yaml
@@ -72,12 +72,13 @@ resourceDiscoveryGroups: []
 #       - westeurope
 
 deployment:
-  extraEnv: []
-  # - name: AZURE_STORAGE_QUEUE_SAS_TOKEN
-  #   valueFrom:
-  #     secretKeyRef:
-  #       name: promitor-agent-resource-discovery
-  #       key: azure-storage-queue-sas-token
+  env:
+    extra: []
+    # - name: AZURE_STORAGE_QUEUE_SAS_TOKEN
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: promitor-agent-resource-discovery
+    #       key: azure-storage-queue-sas-token
 
 secrets:
   # To use your own secret, set createSecret to false and define the name/keys that your secret uses

--- a/promitor-agent-resource-discovery/values.yaml
+++ b/promitor-agent-resource-discovery/values.yaml
@@ -76,14 +76,16 @@ deployment:
   # - name: AZURE_STORAGE_QUEUE_SAS_TOKEN
   #   valueFrom:
   #     secretKeyRef:
-  #       name: azure-storage-queue
-  #       key: sas-token
+  #       name: promitor-agent-resource-discovery
+  #       key: azure-storage-queue-sas-token
 
 secrets:
   # To use your own secret, set createSecret to false and define the name/keys that your secret uses
   createSecret: true
   secretName: ""
   appKeySecret: azure-app-key
+  extra: {}
+  # azure-storage-queue-sas-token: <value>
 
 service:
   port: 8889

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -147,6 +147,7 @@ their default values.
 | `service.loadbalancer.enabled`  | Indication whether or not to expose service externally through a load balancer | `false`            |
 | `service.loadbalancer.azure.dnsPrefix`  | **[Azure Kubernetes Service only]** Prefix for DNS name to expose the service on using `<name>.<location>.cloudapp.azure.com` format. ([docs](https://docs.microsoft.com/en-us/azure/aks/static-ip#apply-a-dns-label-to-the-service)) | ``            |
 | `service.loadbalancer.azure.exposeInternally`  | To restrict access to Promitor by exposing it through an internal load balancer. This setting is specific to Azure Kubernetes Service ([docs](https://docs.microsoft.com/en-us/azure/aks/internal-lb)) | `false`            |
+| `deployment.extraEnv`  | Add extra environment variables to the promitor deployment | `[]` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`. For example:

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -142,6 +142,7 @@ their default values.
 | `resources`  | Pod resource requests & limits |    `{}`    |
 | `secrets.createSecret`  | Indication if you want to bring your own secret level of logging | `true`            |
 | `secrets.appKeySecret`  | Name of the secret for Azure AD identity secret | `azure-app-key`            |
+| `secrets.extra`  | Add extra secrets | `{}` |
 | `service.port`  | Port on service for other pods to talk to | `8888`            |
 | `service.targetPort`  | Port on container to serve traffic | `5000`            |
 | `service.loadbalancer.enabled`  | Indication whether or not to expose service externally through a load balancer | `false`            |

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -148,7 +148,7 @@ their default values.
 | `service.loadbalancer.enabled`  | Indication whether or not to expose service externally through a load balancer | `false`            |
 | `service.loadbalancer.azure.dnsPrefix`  | **[Azure Kubernetes Service only]** Prefix for DNS name to expose the service on using `<name>.<location>.cloudapp.azure.com` format. ([docs](https://docs.microsoft.com/en-us/azure/aks/static-ip#apply-a-dns-label-to-the-service)) | ``            |
 | `service.loadbalancer.azure.exposeInternally`  | To restrict access to Promitor by exposing it through an internal load balancer. This setting is specific to Azure Kubernetes Service ([docs](https://docs.microsoft.com/en-us/azure/aks/internal-lb)) | `false`            |
-| `deployment.extraEnv`  | Add extra environment variables to the promitor deployment | `[]` |
+| `deployment.env.extra`  | Add extra environment variables to the promitor deployment | `[]` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to
 `helm install`. For example:

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-  {{- if or (or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey (eq .Values.secrets.createSecret false)) (or (.Values.metricSinks.atlassianStatuspage.apiKey) (and (eq .Values.metricSinks.atlassianStatuspage.enabled true) (eq .Values.secrets.createSecret false))) .Values.deployment.extraEnv }}
+  {{- if or (or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey (eq .Values.secrets.createSecret false)) (or (.Values.metricSinks.atlassianStatuspage.apiKey) (and (eq .Values.metricSinks.atlassianStatuspage.enabled true) (eq .Values.secrets.createSecret false))) .Values.deployment.env.extra }}
           env:
   {{- if or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey (eq .Values.secrets.createSecret false) }}
           - name: PROMITOR_AUTH_APPKEY
@@ -90,8 +90,8 @@ spec:
                   name: {{ template "promitor-agent-scraper.secretname" . }}
                   key: {{ .Values.secrets.atlassianStatuspageApiKey }}
   {{- end }}
-  {{- if .Values.deployment.extraEnv }}
-{{ toYaml .Values.deployment.extraEnv | indent 12 }}
+  {{- if .Values.deployment.env.extra }}
+{{ toYaml .Values.deployment.env.extra | indent 12 }}
   {{- end }}
   {{- end }}
           resources:

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -74,8 +74,9 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
+  {{- if or (or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey (eq .Values.secrets.createSecret false)) (or (.Values.metricSinks.atlassianStatuspage.apiKey) (and (eq .Values.metricSinks.atlassianStatuspage.enabled true) (eq .Values.secrets.createSecret false))) .Values.deployment.extraEnv }}
           env:
-  {{- if or (or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey) (eq .Values.secrets.createSecret false) }}
+  {{- if or .Values.azureAuthentication.identity.key .Values.azureAuthentication.appKey (eq .Values.secrets.createSecret false) }}
           - name: PROMITOR_AUTH_APPKEY
             valueFrom:
               secretKeyRef:
@@ -88,6 +89,10 @@ spec:
               secretKeyRef:
                   name: {{ template "promitor-agent-scraper.secretname" . }}
                   key: {{ .Values.secrets.atlassianStatuspageApiKey }}
+  {{- end }}
+  {{- if .Values.deployment.extraEnv }}
+{{ toYaml .Values.deployment.extraEnv | indent 12 }}
+  {{- end }}
   {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}

--- a/promitor-agent-scraper/templates/secret.yaml
+++ b/promitor-agent-scraper/templates/secret.yaml
@@ -16,4 +16,7 @@ data:
   {{- if .Values.metricSinks.atlassianStatuspage.apiKey }}
   {{ .Values.secrets.atlassianStatuspageApiKey }}: {{ .Values.metricSinks.atlassianStatuspage.apiKey | b64enc | quote }}
   {{- end }}
+  {{- range $key, $value := .Values.secrets.extra }}
+  {{ $key }}: {{ $value | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -118,6 +118,7 @@ secrets:
   secretName: ""
   appKeySecret: azure-app-key
   atlassianStatuspageApiKey: atlassian-statuspage-apikey
+  extra: {}
 
 service:
   port: 8888

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -104,6 +104,14 @@ metrics: []
 #       - namespace: promitor-messaging
 #         queueName: orders
 
+deployment:
+  extraEnv: []
+  # - name: AZURE_STORAGE_QUEUE_SAS_TOKEN
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: azure-storage-queue
+  #       key: sas-token
+
 secrets:
   # To use your own secret, set createSecret to false and define the name/keys that your secret uses
   createSecret: true

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -105,12 +105,13 @@ metrics: []
 #         queueName: orders
 
 deployment:
-  extraEnv: []
-  # - name: AZURE_STORAGE_QUEUE_SAS_TOKEN
-  #   valueFrom:
-  #     secretKeyRef:
-  #       name: azure-storage-queue
-  #       key: sas-token
+  env:
+    extra: []
+    # - name: AZURE_STORAGE_QUEUE_SAS_TOKEN
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: azure-storage-queue
+    #       key: sas-token
 
 secrets:
   # To use your own secret, set createSecret to false and define the name/keys that your secret uses


### PR DESCRIPTION
This PR adds an optional `extraEnv` config, to allow adding custom ENV-variables to the promitor-agent-scraper Deployment.

Fixes #105