### PR TITLE
fix: correct indention of extra env variables (#108)

### DIFF
--- a/promitor-agent-resource-discovery/templates/deployment.yaml
+++ b/promitor-agent-resource-discovery/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
                   key: {{ .Values.secrets.appKeySecret }}
         {{- end }}
         {{- if .Values.deployment.env.extra }}
-{{ toYaml .Values.deployment.env.extra | indent 12 }}
+{{ toYaml .Values.deployment.env.extra | indent 10 }}
         {{- end }}
         {{- end }}
           resources:

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -91,7 +91,7 @@ spec:
                   key: {{ .Values.secrets.atlassianStatuspageApiKey }}
   {{- end }}
   {{- if .Values.deployment.env.extra }}
-{{ toYaml .Values.deployment.env.extra | indent 12 }}
+{{ toYaml .Values.deployment.env.extra | indent 10 }}
   {{- end }}
   {{- end }}
           resources:


### PR DESCRIPTION
We need to use 10 instead of 12 spaces because the other ENV-variables also use 10.

Fixes #108