### PR TITLE
fix: fail on missing secret name (#107)

### DIFF
--- a/promitor-agent-resource-discovery/templates/_helpers.tpl
+++ b/promitor-agent-resource-discovery/templates/_helpers.tpl
@@ -58,7 +58,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.secrets.createSecret -}}
 {{ template "promitor-agent-resource-discovery.fullname" . }}
 {{- else -}}
-{{- printf "%s" .Values.secrets.secretName -}}
+{{- printf "%s" (required "'.secrets.secretName' is required" .Values.secrets.secretName) -}}
 {{- end -}}
 {{- end -}}
 

--- a/promitor-agent-scraper/templates/_helpers.tpl
+++ b/promitor-agent-scraper/templates/_helpers.tpl
@@ -58,7 +58,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.secrets.createSecret -}}
 {{ template "promitor-agent-scraper.fullname" . }}
 {{- else -}}
-{{- printf "%s" .Values.secrets.secretName -}}
+{{- printf "%s" (required "'.secrets.secretName' is required" .Values.secrets.secretName) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Fixes #107

## promitor-agent-scraper

**Without secret name**

```sh
$ helm template promitor ./promitor-agent-scraper \
> --set secrets.createSecret=false \
> --set azureAuthentication.identity.key=foo
Error: execution error at (promitor-agent-scraper/templates/_helpers.tpl:61:17): '.secrets.secretName' is required
```

:warning: You get an error because `.secrets.secretName` is not set.

**With secret name**

```sh
$ helm template promitor ./promitor-agent-scraper \
> --set secrets.createSecret=false \
> --set azureAuthentication.identity.key=foo \
> --set secrets.secretName=my-custom-secret
---
# Source: promitor-agent-scraper/templates/serviceaccount.yaml
apiVersion: v1
automountServiceAccountToken: false
kind: ServiceAccount
```

:heavy_check_mark: Works fine :tada: 

## promitor-agent-resource-discovery

**Without secret name**

```sh
$ helm template promitor ./promitor-agent-resource-discovery \
> --set secrets.createSecret=false \
> --set azureAuthentication.identity.key=foo
Error: execution error at (promitor-agent-resource-discovery/templates/_helpers.tpl:61:17): '.secrets.secretName' is requird
```

:warning: You get an error because `.secrets.secretName` is not set.

**With secret name**

```sh
$ helm template promitor ./promitor-agent-resource-discovery \
> --set secrets.createSecret=false \
> --set azureAuthentication.identity.key=foo \
> --set secrets.secretName=my-custom-secret
---                                                                                                       
# Source: promitor-agent-resource-discovery/templates/serviceaccount.yaml                                 
apiVersion: v1                                                                                            
kind: ServiceAccount                                                                                      
metadata:
# ...
```

:heavy_check_mark: Works fine :tada: 