### PR TITLE
feat: add support for docker image pull secret in promitor-agent-resource-discovery

### DIFF
--- a/promitor-agent-resource-discovery/README.md
+++ b/promitor-agent-resource-discovery/README.md
@@ -60,6 +60,7 @@ their default values.
 | `image.repository`  | Repository which provides the image | `containers.promitor.io/tomkerkhove/promitor-agent-resource-discovery` |
 | `image.tag`  | Tag of image to use | None, chart app version is used by default            |
 | `image.pullPolicy`  | Policy to pull image | `Always`            |
+| `image.pullSecrets`  | ImagePullSecrets for the pod | `[]`            |
 | `azureLandscape.cloud`  | Azure Cloud to discover resources in. Options are `Global` (default), `China`, `UsGov` & `Germany` | `Global`            |
 | `azureLandscape.tenantId`  | Id of Azure tenant to discover resources in |             |
 | `azureLandscape.subscriptions`  | List of Azure subscription ids to discover resources in | `[]`            |

--- a/promitor-agent-resource-discovery/templates/deployment.yaml
+++ b/promitor-agent-resource-discovery/templates/deployment.yaml
@@ -40,6 +40,10 @@ spec:
       {{- if .Values.rbac.create }}
       serviceAccountName: {{ template "promitor-agent-resource-discovery.serviceaccountname" . }}
       {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.nodeSelector | nindent 8 }}

--- a/promitor-agent-resource-discovery/values.yaml
+++ b/promitor-agent-resource-discovery/values.yaml
@@ -9,6 +9,7 @@ fullnameOverride: ""
 image:
   repository: containers.promitor.io/tomkerkhove/promitor-agent-resource-discovery
   pullPolicy: Always
+  pullSecrets: []
   tag:
 
 azureAuthentication:


### PR DESCRIPTION
We need the support for imagePullSecret in promitor-agent-resource-discovery helm chart.