### PR TITLE
fix: change secretKeyRef field indentation from 4 to 2

### DIFF
--- a/promitor-agent-resource-discovery/templates/deployment.yaml
+++ b/promitor-agent-resource-discovery/templates/deployment.yaml
@@ -66,8 +66,8 @@ spec:
           - name: PROMITOR_AUTH_APPKEY
             valueFrom:
               secretKeyRef:
-                  name: {{ template "promitor-agent-resource-discovery.secretname" . }}
-                  key: {{ .Values.secrets.appKeySecret }}
+                name: {{ template "promitor-agent-resource-discovery.secretname" . }}
+                key: {{ .Values.secrets.appKeySecret }}
         {{- end }}
         {{- if .Values.deployment.env.extra }}
 {{ toYaml .Values.deployment.env.extra | indent 10 }}

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -80,15 +80,15 @@ spec:
           - name: PROMITOR_AUTH_APPKEY
             valueFrom:
               secretKeyRef:
-                  name: {{ template "promitor-agent-scraper.secretname" . }}
-                  key: {{ .Values.secrets.appKeySecret }}
+                name: {{ template "promitor-agent-scraper.secretname" . }}
+                key: {{ .Values.secrets.appKeySecret }}
   {{- end}}
   {{- if or (.Values.metricSinks.atlassianStatuspage.apiKey) (and (eq .Values.metricSinks.atlassianStatuspage.enabled true) (eq .Values.secrets.createSecret false)) }}
           - name: PROMITOR_ATLASSIAN_STATUSPAGE_APIKEY
             valueFrom:
               secretKeyRef:
-                  name: {{ template "promitor-agent-scraper.secretname" . }}
-                  key: {{ .Values.secrets.atlassianStatuspageApiKey }}
+                name: {{ template "promitor-agent-scraper.secretname" . }}
+                key: {{ .Values.secrets.atlassianStatuspageApiKey }}
   {{- end }}
   {{- if .Values.deployment.env.extra }}
 {{ toYaml .Values.deployment.env.extra | indent 10 }}


### PR DESCRIPTION
Signed-off-by: Kirill Petrov <yakutskkirill@mail.ru>

Hi, thanks for your Promitor service. I find it the most suitable way to monitor resources created by Crossplane in our clusters.

We use it in ArgoCD GitOps as helm + kustomize. We have an amount of linters over generated manifests.

# Fixes 

YAML Lint fails on generated manifests with error:
```
error    wrong indentation: expected 16 but found 18
```
This small PR makes indentation consistent everywhere.