### PR TITLE
feat: add mutex timeout config

### DIFF
--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -61,6 +61,7 @@ their default values.
 | `image.tag`  | Tag of image to use | None, chart app version is used by default            |
 | `image.pullPolicy`  | Policy to pull image | `Always`            |
 | `image.pullSecrets`  | ImagePullSecrets for the pod | `[]`            |
+| `concurrency.mutexTimeoutSeconds` | A scrape job's maximum time hold(in seconds) a scraping mutex. | `90`
 | `azureAuthentication.appId`  | [Deprecated] Use `azureAuthentication.identity.id` instead |             |
 | `azureAuthentication.appKey`  | [Deprecated] User `azureAuthentication.identity.key` instead |             |
 | `azureAuthentication.mode`  | Authentication type to use to authenticate. Options are `ServicePrincipal` (default), `UserAssignedManagedIdentity` or `SystemAssignedManagedIdentity` |             |

--- a/promitor-agent-scraper/templates/configmap.yaml
+++ b/promitor-agent-scraper/templates/configmap.yaml
@@ -11,6 +11,10 @@ data:
   runtime.yaml: |-
       server:
         httpPort: {{ .Values.service.targetPort | quote }}
+  {{- if .Values.concurrency.mutexTimeoutSeconds }}
+      concurrency:
+        mutexTimeoutSeconds: {{ .Values.concurrency.mutexTimeoutSeconds }}
+  {{- end }}
       authentication:
         mode: {{ .Values.azureAuthentication.mode | default "ServicePrincipal"}}
   {{- if .Values.azureAuthentication.identity.id }}

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -20,6 +20,8 @@ azureAuthentication:
     id: ""
     key: ""
     binding: ""
+concurrency:
+  mutexTimeoutSeconds: 90
 metricSinks:
   atlassianStatuspage:
     enabled: false


### PR DESCRIPTION
This PR continues the work started in #181 (originally by @hkfgo) and addresses the requested feedback, including:

- Updating image version to 2.14.0 to support `mutexTimeout`
- Updating chart configuration accordingly

Since the original author appears to be unavailable, this aims to move it forward.