### PR TITLE
feat: add mutex timeout config

### DIFF
--- a/promitor-agent-scraper/Chart.yaml
+++ b/promitor-agent-scraper/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 version: 2.14.0
-appVersion: 2.13.0
+appVersion: 2.14.0
 type: application
 name: promitor-agent-scraper
 description: Promitor, bringing Azure Monitor metrics where you need them.

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -61,13 +61,13 @@ their default values.
 | `image.tag`  | Tag of image to use | None, chart app version is used by default            |
 | `image.pullPolicy`  | Policy to pull image | `Always`            |
 | `image.pullSecrets`  | ImagePullSecrets for the pod | `[]`            |
-| `concurrency.mutexTimeoutSeconds` | A scrape job's maximum time hold(in seconds) a scraping mutex. | `90`
 | `azureAuthentication.appId`  | [Deprecated] Use `azureAuthentication.identity.id` instead |             |
 | `azureAuthentication.appKey`  | [Deprecated] User `azureAuthentication.identity.key` instead |             |
 | `azureAuthentication.mode`  | Authentication type to use to authenticate. Options are `ServicePrincipal` (default), `UserAssignedManagedIdentity` or `SystemAssignedManagedIdentity` |             |
 | `azureAuthentication.identity.id`  | Id of the Azure AD entity to authenticate with |             |
 | `azureAuthentication.identity.key`  | Secret of the Azure AD entity to authenticate with |             |
 | `azureAuthentication.identity.binding`  | Aad Pod Identity name, when using `UserAssignedManagedIdentity` or `SystemAssignedManagedIdentity` as mode |             |
+| `concurrency.mutexTimeoutSeconds` | A scrape job's maximum time hold(in seconds) a scraping mutex. | `90`            |
 | `resourceDiscovery.enabled`  | Indication whether or not resource discovery is required | `false`            |
 | `resourceDiscovery.host`  | DNS name or IP address of the Promitor Resource Discovery agent |             |
 | `resourceDiscovery.port`  | Port (UDP) address of the Promitor Resource Discovery agent | `80`            |

--- a/promitor-agent-scraper/README.md
+++ b/promitor-agent-scraper/README.md
@@ -61,6 +61,7 @@ their default values.
 | `image.tag`  | Tag of image to use | None, chart app version is used by default            |
 | `image.pullPolicy`  | Policy to pull image | `Always`            |
 | `image.pullSecrets`  | ImagePullSecrets for the pod | `[]`            |
+| `concurrency.mutexTimeoutSeconds` | A scrape job's maximum time hold(in seconds) a scraping mutex. | `90`
 | `azureAuthentication.appId`  | [Deprecated] Use `azureAuthentication.identity.id` instead |             |
 | `azureAuthentication.appKey`  | [Deprecated] User `azureAuthentication.identity.key` instead |             |
 | `azureAuthentication.mode`  | Authentication type to use to authenticate. Options are `ServicePrincipal` (default), `UserAssignedManagedIdentity` or `SystemAssignedManagedIdentity` |             |

--- a/promitor-agent-scraper/templates/configmap.yaml
+++ b/promitor-agent-scraper/templates/configmap.yaml
@@ -11,6 +11,10 @@ data:
   runtime.yaml: |-
       server:
         httpPort: {{ .Values.service.targetPort | quote }}
+  {{- if .Values.concurrency.mutexTimeoutSeconds }}
+      concurrency:
+        mutexTimeoutSeconds: {{ .Values.concurrency.mutexTimeoutSeconds }}
+  {{- end }}
       authentication:
         mode: {{ .Values.azureAuthentication.mode | default "ServicePrincipal"}}
   {{- if .Values.azureAuthentication.identity.id }}

--- a/promitor-agent-scraper/values.yaml
+++ b/promitor-agent-scraper/values.yaml
@@ -20,6 +20,8 @@ azureAuthentication:
     id: ""
     key: ""
     binding: ""
+concurrency:
+  mutexTimeoutSeconds: 90
 metricSinks:
   atlassianStatuspage:
     enabled: false


### PR DESCRIPTION
This PR continues the work started in https://github.com/promitor/charts/pull/181 (originally by @hkfgo) and addresses the requested feedback, including:

Updating image version to 2.14.0 to support mutexTimeout
Updating chart configuration accordingly
Since the original author is unavailable, this aims to move it forward.