### PR TITLE
fix: use name helper for container name so camelCase aliases work

### DIFF
--- a/promitor-agent-resource-discovery/templates/deployment.yaml
+++ b/promitor-agent-resource-discovery/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
         {{- toYaml .Values.tolerations | nindent 6 }}
       {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ template "promitor-agent-resource-discovery.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:

--- a/promitor-agent-scraper/templates/deployment.yaml
+++ b/promitor-agent-scraper/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
         {{- toYaml .Values.tolerations | nindent 6 }}
       {{- end }}
       containers:
-        - name: {{ .Chart.Name }}
+        - name: {{ template "promitor-agent-scraper.name" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:


### PR DESCRIPTION
Fixes #201.

Both deployment templates set the container name from `.Chart.Name`. When the chart is pulled in under an `alias` in a parent chart's `dependencies`, Helm sets `.Chart.Name` to the alias — and if that alias is camelCase (e.g. `promitorDiscovery`), the render produces an invalid RFC 1123 container name and the deploy is rejected.

This switches both templates to the existing `*.name` helper, which honors `nameOverride` and falls back to `.Chart.Name` otherwise. No change for existing users; it only fixes the aliased case.
